### PR TITLE
removing btc/ltc references

### DIFF
--- a/brontide/noise.go
+++ b/brontide/noise.go
@@ -20,7 +20,7 @@ const (
 	// protocolName is the precise instantiation of the Noise protocol
 	// handshake at the center of Brontide. This value will be used as part
 	// of the prologue. If the initiator and responder aren't using the
-	// exact same string for this value, along with prologue of the Bitcoin
+	// exact same string for this value, along with prologue of the Decred
 	// network, then the initial handshake will fail.
 	protocolName = "Noise_XK_secp256k1_ChaChaPoly_SHA256"
 

--- a/chainntnfs/dcrdnotify/dcrd_dev.go
+++ b/chainntnfs/dcrdnotify/dcrd_dev.go
@@ -16,7 +16,7 @@ import (
 // UnsafeStart starts the notifier with a specified best height and optional
 // best hash. Its bestBlock and txNotifier are initialized with bestHeight and
 // optionally bestHash. The parameter generateBlocks is necessary for the
-// bitcoind notifier to ensure we drain all notifications up to syncHeight,
+// dcrd notifier to ensure we drain all notifications up to syncHeight,
 // since if they are generated ahead of UnsafeStart the chainConn may start up
 // with an outdated best block and miss sending ntfns. Used for testing.
 func (b *DcrdNotifier) UnsafeStart(bestHeight int64, bestHash *chainhash.Hash,

--- a/chainntnfs/interface_test.go
+++ b/chainntnfs/interface_test.go
@@ -288,7 +288,7 @@ func testSpendNotification(miner *rpctest.Harness,
 	// all the spend clients, such that we can wait for them all in
 	// parallel.
 	//
-	// Since bitcoind is at times very slow at notifying about txs in the
+	// Since dcrd is at times very slow at notifying about txs in the
 	// mempool, we use a quite large timeout of 10 seconds.
 	// TODO(halseth): change this when mempool spends are removed.
 	mempoolSpendTimeout := 10 * time.Second

--- a/chainparams.go
+++ b/chainparams.go
@@ -7,7 +7,7 @@ import (
 )
 
 // activeNetParams is a pointer to the parameters specific to the currently
-// active bitcoin network.
+// active decred network.
 var activeNetParams = decredTestNetParams
 
 // decredNetParams couples the p2p parameters of a network with the
@@ -18,7 +18,7 @@ type decredNetParams struct {
 	CoinType uint32
 }
 
-// bitcoinTestNetParams contains parameters specific to the 3rd version of the
+// decredTestNetParams contains parameters specific to the 3rd version of the
 // test network.
 var decredTestNetParams = decredNetParams{
 	Params:   &chaincfg.TestNet3Params,

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -36,11 +36,11 @@ const (
 	defaultDecredStaticFeePerKB = lnwallet.AtomPerKByte(1e4)
 )
 
-// defaultBtcChannelConstraints is the default set of channel constraints that are
-// meant to be used when initially funding a Bitcoin channel.
+// defaultDcrChannelConstraints is the default set of channel constraints that are
+// meant to be used when initially funding a Decred channel.
 //
 // TODO(halseth): make configurable at startup?
-var defaultBtcChannelConstraints = channeldb.ChannelConstraints{
+var defaultDcrChannelConstraints = channeldb.ChannelConstraints{
 	DustLimit:        lnwallet.DefaultDustLimit(),
 	MaxAcceptedHtlcs: lnwallet.MaxHTLCNumber / 2,
 }
@@ -226,7 +226,7 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 			}
 		}
 
-		// If the specified host for the btcd RPC server already
+		// If the specified host for the dcrd RPC server already
 		// has a port specified, then we use that directly. Otherwise,
 		// we assume the default port according to the selected chain
 		// parameters.
@@ -323,7 +323,7 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 	cc.wc = wc
 
 	// Select the default channel constraints for the primary chain.
-	channelConstraints := defaultBtcChannelConstraints
+	channelConstraints := defaultDcrChannelConstraints
 
 	keyRing := keychain.NewWalletKeyRing(
 		wc.InternalWallet(),

--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -576,10 +576,10 @@ func assertEdgeInfoEqual(t *testing.T, e1 *ChannelEdgeInfo,
 		t.Fatalf("nodekey2 doesn't match")
 	}
 	if !bytes.Equal(e1.DecredKey1Bytes[:], e2.DecredKey1Bytes[:]) {
-		t.Fatalf("bitcoinkey1 doesn't match")
+		t.Fatalf("decredkey1 doesn't match")
 	}
 	if !bytes.Equal(e1.DecredKey2Bytes[:], e2.DecredKey2Bytes[:]) {
-		t.Fatalf("bitcoinkey2 doesn't match")
+		t.Fatalf("decredkey2 doesn't match")
 	}
 
 	if !bytes.Equal(e1.Features, e2.Features) {
@@ -596,10 +596,10 @@ func assertEdgeInfoEqual(t *testing.T, e1 *ChannelEdgeInfo,
 		t.Fatalf("nodesig2 doesn't match")
 	}
 	if !bytes.Equal(e1.AuthProof.DecredSig1Bytes, e2.AuthProof.DecredSig1Bytes) {
-		t.Fatalf("bitcoinsig1 doesn't match")
+		t.Fatalf("decredsig1 doesn't match")
 	}
 	if !bytes.Equal(e1.AuthProof.DecredSig2Bytes, e2.AuthProof.DecredSig2Bytes) {
-		t.Fatalf("bitcoinsig2 doesn't match")
+		t.Fatalf("decredsig2 doesn't match")
 	}
 
 	if e1.ChannelPoint != e2.ChannelPoint {

--- a/channeldb/nodes.go
+++ b/channeldb/nodes.go
@@ -20,10 +20,10 @@ var (
 )
 
 // LinkNode stores metadata related to node's that we have/had a direct
-// channel open with. Information such as the Bitcoin network the node
+// channel open with. Information such as the Decred network the node
 // advertised, and its identity public key are also stored. Additionally, this
 // struct and the bucket its stored within have store data similar to that of
-// Bitcoin's addrmanager. The TCP address information stored within the struct
+// Decred's addrmanager. The TCP address information stored within the struct
 // can be used to establish persistent connections will all channel
 // counterparties on daemon startup.
 //
@@ -31,7 +31,7 @@ var (
 // TODO(roasbeef): add bitfield for supported services
 //  * possibly add a wire.NetAddress type, type
 type LinkNode struct {
-	// Network indicates the Bitcoin network that the LinkNode advertises
+	// Network indicates the Decred network that the LinkNode advertises
 	// for incoming channel creation.
 	Network wire.CurrencyNet
 

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -141,10 +141,10 @@ func newAddress(ctx *cli.Context) error {
 var sendCoinsCommand = cli.Command{
 	Name:      "sendcoins",
 	Category:  "On-chain",
-	Usage:     "Send bitcoin on-chain to an address.",
+	Usage:     "Send decred on-chain to an address.",
 	ArgsUsage: "addr amt",
 	Description: `
-	Send amt coins in atoms to the BASE58 encoded bitcoin address addr.
+	Send amt coins in atoms to the BASE58 encoded decred address addr.
 
 	Fees used when sending the transaction can be specified via the --conf_target, or
 	--atoms_per_byte optional flags.
@@ -154,12 +154,12 @@ var sendCoinsCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "addr",
-			Usage: "the BASE58 encoded bitcoin address to send coins to on-chain",
+			Usage: "the BASE58 encoded decred address to send coins to on-chain",
 		},
 		// TODO(roasbeef): switch to DCR on command line? int may not be sufficient
 		cli.Int64Flag{
 			Name:  "amt",
-			Usage: "the number of bitcoin denominated in atoms to send",
+			Usage: "the number of decred denominated in atoms to send",
 		},
 		cli.Int64Flag{
 			Name: "conf_target",
@@ -335,7 +335,7 @@ func listUnspent(ctx *cli.Context) error {
 var sendManyCommand = cli.Command{
 	Name:      "sendmany",
 	Category:  "On-chain",
-	Usage:     "Send bitcoin on-chain to multiple addresses.",
+	Usage:     "Send decred on-chain to multiple addresses.",
 	ArgsUsage: "send-json-string [--conf_target=N] [--atoms_per_byte=P]",
 	Description: `
 	Create and broadcast a transaction paying the specified amount(s) to the passed address(es).

--- a/contractcourt/contract_resolvers.go
+++ b/contractcourt/contract_resolvers.go
@@ -28,7 +28,7 @@ const (
 )
 
 // ContractResolver is an interface which packages a state machine which is
-// able to carry out the necessary steps required to fully resolve a Bitcoin
+// able to carry out the necessary steps required to fully resolve a Decred
 // contract on-chain. Resolvers are fully encodable to ensure callers are able
 // to persist them properly. A resolver may produce another resolver in the
 // case that claiming an HTLC is a multi-stage process. In this case, we may

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2095,7 +2095,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 
 		// By the specification, channel announcement proofs should be
 		// sent after some number of confirmations after channel was
-		// registered in bitcoin blockchain. Therefore, we check if the
+		// registered in decred blockchain. Therefore, we check if the
 		// proof is premature.  If so we'll halt processing until the
 		// expected announcement height.  This allows us to be tolerant
 		// to other clients if this constraint was changed.
@@ -2307,9 +2307,9 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 		}
 
 		// If the channel was returned by the router it means that
-		// existence of funding point and inclusion of nodes bitcoin
+		// existence of funding point and inclusion of nodes decred
 		// keys in it already checked by the router. In this stage we
-		// should check that node keys are attest to the bitcoin keys
+		// should check that node keys are attest to the decred keys
 		// by validating the signatures of announcement.  If proof is
 		// valid then we'll populate the channel edge with it, so we
 		// can announce it on peer connect.

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -38,14 +38,14 @@ var (
 	_, _ = testSig.R.SetString("63724406601629180062774974542967536251589935445068131219452686511677818569431", 10)
 	_, _ = testSig.S.SetString("18801056069249825825291287104931333862866033135609736119018462340006816851118", 10)
 
-	bitcoinKeyPriv1, _ = secp256k1.GeneratePrivateKey()
-	bitcoinKeyPub1     = bitcoinKeyPriv1.PubKey()
+	decredKeyPriv1, _ = secp256k1.GeneratePrivateKey()
+	decredKeyPub1     = decredKeyPriv1.PubKey()
 
 	nodeKeyPriv1, _ = secp256k1.GeneratePrivateKey()
 	nodeKeyPub1     = nodeKeyPriv1.PubKey()
 
-	bitcoinKeyPriv2, _ = secp256k1.GeneratePrivateKey()
-	bitcoinKeyPub2     = bitcoinKeyPriv2.PubKey()
+	decredKeyPriv2, _ = secp256k1.GeneratePrivateKey()
+	decredKeyPub2     = decredKeyPriv2.PubKey()
 
 	nodeKeyPriv2, _ = secp256k1.GeneratePrivateKey()
 	nodeKeyPub2     = nodeKeyPriv2.PubKey()
@@ -485,8 +485,8 @@ func createAnnouncementWithoutProof(blockHeight uint32,
 	}
 	copy(a.NodeID1[:], nodeKeyPub1.SerializeCompressed())
 	copy(a.NodeID2[:], nodeKeyPub2.SerializeCompressed())
-	copy(a.DecredKey1[:], bitcoinKeyPub1.SerializeCompressed())
-	copy(a.DecredKey2[:], bitcoinKeyPub2.SerializeCompressed())
+	copy(a.DecredKey1[:], decredKeyPub1.SerializeCompressed())
+	copy(a.DecredKey2[:], decredKeyPub2.SerializeCompressed())
 	if len(extraBytes) == 1 {
 		a.ExtraOpaqueData = extraBytes[0]
 	}
@@ -521,8 +521,8 @@ func createRemoteChannelAnnouncement(blockHeight uint32,
 		return nil, err
 	}
 
-	pub = bitcoinKeyPriv1.PubKey()
-	signer = mockSigner{bitcoinKeyPriv1}
+	pub = decredKeyPriv1.PubKey()
+	signer = mockSigner{decredKeyPriv1}
 	sig, err = SignAnnouncement(&signer, pub, a)
 	if err != nil {
 		return nil, err
@@ -532,8 +532,8 @@ func createRemoteChannelAnnouncement(blockHeight uint32,
 		return nil, err
 	}
 
-	pub = bitcoinKeyPriv2.PubKey()
-	signer = mockSigner{bitcoinKeyPriv2}
+	pub = decredKeyPriv2.PubKey()
+	signer = mockSigner{decredKeyPriv2}
 	sig, err = SignAnnouncement(&signer, pub, a)
 	if err != nil {
 		return nil, err
@@ -1949,7 +1949,7 @@ func TestDeDuplicatedAnnouncements(t *testing.T) {
 		t.Fatalf("can't create remote channel announcement: %v", err)
 	}
 
-	nodePeer := &mockPeer{bitcoinKeyPub2, nil, nil}
+	nodePeer := &mockPeer{decredKeyPub2, nil, nil}
 	announcements.AddMsgs(networkMsg{
 		msg:    ca,
 		peer:   nodePeer,

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -2395,14 +2395,6 @@ func (f *fundingManager) handleFundingLocked(fmsg *fundingLockedMsg) {
 	}
 }
 
-// channelProof is one half of the proof necessary to create an authenticated
-// announcement on the network. The two signatures individually sign a
-// statement of the existence of a channel.
-type channelProof struct {
-	nodeSig    *secp256k1.Signature
-	bitcoinSig *secp256k1.Signature
-}
-
 // chanAnnouncement encapsulates the two authenticated announcements that we
 // send out to the network after a new channel has been created locally.
 type chanAnnouncement struct {
@@ -2521,7 +2513,7 @@ func (f *fundingManager) newChanAnnouncement(localPubKey, remotePubKey,
 	}
 	decredSig, err := f.cfg.SignMessage(localFundingKey, chanAnnMsg)
 	if err != nil {
-		return nil, errors.Errorf("unable to generate bitcoin "+
+		return nil, errors.Errorf("unable to generate decred "+
 			"signature for node public key: %v", err)
 	}
 

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -216,7 +216,7 @@ func createTestWallet(cdb *channeldb.DB, netParams *chaincfg.Params,
 		ChainIO:            bio,
 		FeeEstimator:       estimator,
 		NetParams:          *netParams,
-		DefaultConstraints: defaultBtcChannelConstraints,
+		DefaultConstraints: defaultDcrChannelConstraints,
 	})
 	if err != nil {
 		return nil, err

--- a/lnwallet/dcrwallet/wallet.go
+++ b/lnwallet/dcrwallet/wallet.go
@@ -219,7 +219,7 @@ func (b *DcrWallet) IsOurAddress(a dcrutil.Address) bool {
 	return result && (err == nil)
 }
 
-// SendOutputs funds, signs, and broadcasts a Bitcoin transaction paying out to
+// SendOutputs funds, signs, and broadcasts a Decred transaction paying out to
 // the specified outputs. In the case the wallet has insufficient funds, or the
 // outputs are non-standard, a non-nil error will be returned.
 //
@@ -322,7 +322,7 @@ func (b *DcrWallet) ListUnspentWitness(minConfs, maxConfs int32) (
 }
 
 // PublishTransaction performs cursory validation (dust checks, etc), then
-// finally broadcasts the passed transaction to the Bitcoin network. If
+// finally broadcasts the passed transaction to the Decred network. If
 // publishing the transaction fails, an error describing the reason is
 // returned (currently ErrDoubleSpend). If the transaction is already
 // published to the network (either in the mempool or chain) no error

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -162,7 +162,7 @@ type WalletController interface {
 	// IsOurAddress checks if the passed address belongs to this wallet
 	IsOurAddress(a dcrutil.Address) bool
 
-	// SendOutputs funds, signs, and broadcasts a Bitcoin transaction paying
+	// SendOutputs funds, signs, and broadcasts a Decred transaction paying
 	// out to the specified outputs. In the case the wallet has insufficient
 	// funds, or the outputs are non-standard, an error should be returned.
 	// This method also takes the target fee expressed in atoms/kw that should
@@ -194,7 +194,7 @@ type WalletController interface {
 	UnlockOutpoint(o wire.OutPoint)
 
 	// PublishTransaction performs cursory validation (dust checks, etc),
-	// then finally broadcasts the passed transaction to the Bitcoin network.
+	// then finally broadcasts the passed transaction to the Decred network.
 	// If the transaction is rejected because it is conflicting with an
 	// already known transaction, ErrDoubleSpend is returned. If the
 	// transaction is already known (published already), no error will be

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -519,7 +519,7 @@ func (m *mockPreimageCache) AddPreimage(preimage []byte) error {
 	return nil
 }
 
-// pubkeyFromHex parses a Bitcoin public key from a hex encoded string.
+// pubkeyFromHex parses a Decred public key from a hex encoded string.
 func pubkeyFromHex(keyHex string) (*secp256k1.PublicKey, error) {
 	bytes, err := hex.DecodeString(keyHex)
 	if err != nil {
@@ -528,7 +528,7 @@ func pubkeyFromHex(keyHex string) (*secp256k1.PublicKey, error) {
 	return secp256k1.ParsePubKey(bytes)
 }
 
-// privkeyFromHex parses a Bitcoin private key from a hex encoded string.
+// privkeyFromHex parses a Decred private key from a hex encoded string.
 func privkeyFromHex(keyHex string) (*secp256k1.PrivateKey, error) {
 	bytes, err := hex.DecodeString(keyHex)
 	if err != nil {
@@ -539,17 +539,17 @@ func privkeyFromHex(keyHex string) (*secp256k1.PrivateKey, error) {
 
 }
 
-// pubkeyToHex serializes a Bitcoin public key to a hex encoded string.
+// pubkeyToHex serializes a Decred public key to a hex encoded string.
 func pubkeyToHex(key *secp256k1.PublicKey) string {
 	return hex.EncodeToString(key.SerializeCompressed())
 }
 
-// privkeyFromHex serializes a Bitcoin private key to a hex encoded string.
+// privkeyFromHex serializes a Decred private key to a hex encoded string.
 func privkeyToHex(key *secp256k1.PrivateKey) string {
 	return hex.EncodeToString(key.Serialize())
 }
 
-// signatureFromHex parses a Bitcoin signature from a hex encoded string.
+// signatureFromHex parses a Decred signature from a hex encoded string.
 func signatureFromHex(sigHex string) (*secp256k1.Signature, error) {
 	bytes, err := hex.DecodeString(sigHex)
 	if err != nil {
@@ -558,7 +558,7 @@ func signatureFromHex(sigHex string) (*secp256k1.Signature, error) {
 	return secp256k1.ParseSignature(bytes)
 }
 
-// blockFromHex parses a full Bitcoin block from a hex encoded string.
+// blockFromHex parses a full Decred block from a hex encoded string.
 func blockFromHex(blockHex string) (*dcrutil.Block, error) {
 	bytes, err := hex.DecodeString(blockHex)
 	if err != nil {
@@ -567,7 +567,7 @@ func blockFromHex(blockHex string) (*dcrutil.Block, error) {
 	return dcrutil.NewBlockFromBytes(bytes)
 }
 
-// txFromHex parses a full Bitcoin transaction from a hex encoded string.
+// txFromHex parses a full Decred transaction from a hex encoded string.
 func txFromHex(txHex string) (*dcrutil.Tx, error) {
 	bytes, err := hex.DecodeString(txHex)
 	if err != nil {

--- a/mock.go
+++ b/mock.go
@@ -197,7 +197,7 @@ func (*mockChainIO) GetBlock(blockHash *chainhash.Hash) (*wire.MsgBlock, error) 
 }
 
 // mockWalletController is used by the LightningWallet, and let us mock the
-// interaction with the bitcoin network.
+// interaction with the Decred network.
 type mockWalletController struct {
 	rootKey               *secp256k1.PrivateKey
 	prevAddres            dcrutil.Address

--- a/routing/ann_validation.go
+++ b/routing/ann_validation.go
@@ -26,7 +26,7 @@ func ValidateChannelAnn(a *lnwire.ChannelAnnouncement) error {
 
 	// First we'll verify that the passed bitcoin key signature is indeed a
 	// signature over the computed hash digest.
-	bitcoinSig1, err := a.DecredSig1.ToSignature()
+	decredSig1, err := a.DecredSig1.ToSignature()
 	if err != nil {
 		return err
 	}
@@ -34,14 +34,14 @@ func ValidateChannelAnn(a *lnwire.ChannelAnnouncement) error {
 	if err != nil {
 		return err
 	}
-	if !bitcoinSig1.Verify(dataHash, bitcoinKey1) {
+	if !decredSig1.Verify(dataHash, bitcoinKey1) {
 		return errors.New("can't verify first bitcoin signature")
 	}
 
 	// If that checks out, then we'll verify that the second bitcoin
 	// signature is a valid signature of the bitcoin public key over hash
 	// digest as well.
-	bitcoinSig2, err := a.DecredSig2.ToSignature()
+	decredSig2, err := a.DecredSig2.ToSignature()
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func ValidateChannelAnn(a *lnwire.ChannelAnnouncement) error {
 	if err != nil {
 		return err
 	}
-	if !bitcoinSig2.Verify(dataHash, bitcoinKey2) {
+	if !decredSig2.Verify(dataHash, bitcoinKey2) {
 		return errors.New("can't verify second bitcoin signature")
 	}
 

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -114,7 +114,7 @@
 ; Debug logging level.
 ; Valid levels are {trace, debug, info, warn, error, critical}
 ; You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set
-; log level for individual subsystems.  Use btcd --debuglevel=show to list
+; log level for individual subsystems.  Use dcrlnd --debuglevel=show to list
 ; available subsystems.
 ; debuglevel=info
 
@@ -188,7 +188,7 @@ decred.node=dcrd
 ; dcrd.rpccert=~/.dcrd/rpc.cert
 
 ; The raw bytes of the daemon's PEM-encoded certificate chain which will be used
-; to authenticate the RPC connection. This only needs to be set if the btcd
+; to authenticate the RPC connection. This only needs to be set if the dcrd
 ; node is on a remote host.
 ; dcrd.rawrpccert=
 

--- a/server.go
+++ b/server.go
@@ -744,8 +744,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 		NetParams:          activeNetParams.Params,
 	})
 
-	// Select the configuration and furnding parameters for Bitcoin or
-	// Litecoin, depending on the primary registered chain.
+	// Select the configuration and funding parameters for Decred
 	chainCfg := cfg.Decred
 	minRemoteDelay := minDcrRemoteDelay
 	maxRemoteDelay := maxDcrRemoteDelay
@@ -807,8 +806,6 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 			// in the case this gets re-orged out, and
 			// we will require more confirmations before
 			// we consider it open.
-			// TODO(halseth): Use Litecoin params in case
-			// of LTC channels.
 
 			// In case the user has explicitly specified
 			// a default value for the number of
@@ -841,7 +838,6 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 			// close) linearly from minRemoteDelay blocks
 			// for small channels, to maxRemoteDelay blocks
 			// for channels of size maxFundingAmount.
-			// TODO(halseth): Litecoin parameter for LTC.
 
 			// In case the user has explicitly specified
 			// a default value for the remote delay, we

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -204,7 +204,7 @@ type NurseryConfig struct {
 // considered mature after the relative time-lock within the pkScript has
 // passed. As outputs reach their maturity age, they're swept in batches into
 // the source wallet, returning the outputs so they can be used within future
-// channels, or regular Bitcoin transactions.
+// channels, or regular Decred transactions.
 type utxoNursery struct {
 	started uint32 // To be used atomically.
 	stopped uint32 // To be used atomically.

--- a/zpay32/amountunits.go
+++ b/zpay32/amountunits.go
@@ -97,11 +97,11 @@ func decodeAmount(amount string) (lnwire.MilliAtom, error) {
 	char := amount[len(amount)-1]
 	digit := char - '0'
 	if digit <= 9 {
-		btc, err := strconv.ParseUint(amount, 10, 64)
+		dcr, err := strconv.ParseUint(amount, 10, 64)
 		if err != nil {
 			return 0, err
 		}
-		return lnwire.MilliAtom(btc) * mAtPerDcr, nil
+		return lnwire.MilliAtom(dcr) * mAtPerDcr, nil
 	}
 
 	// If not a digit, it must be part of the known units.


### PR DESCRIPTION
- Update "btc" => "dcr" and "bitcoin" => "decred" in many places. Mostly in comments but also some variable names.
- Remove type `channelProof` from `fundingmanager.go`. It isn't used.
- Remove some references to litecoin