### PR TITLE
itest: Fix possible panic

### DIFF
--- a/lnd_test.go
+++ b/lnd_test.go
@@ -5213,7 +5213,7 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	)
 
 	// Make sure all the channels have been opened.
-	nodeNames := []string{"bob", "carol", "dave", "eve"}
+	nodeNames := []string{"bob", "carol", "bob->carol", "dave", "eve"}
 	aliceChans := []*lnrpc.ChannelPoint{
 		chanPointBob, chanPointCarol, chanPointBobCarol, chanPointDave,
 		chanPointEve,


### PR DESCRIPTION
This fixes a possible panic when a timeout occurs in
testInvoiceRoutingHints.

