### PR TITLE
Dcrwallet keyring

### DIFF
--- a/chainregistry.go
+++ b/chainregistry.go
@@ -319,7 +319,7 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 	// Select the default channel constraints for the primary chain.
 	channelConstraints := defaultDcrChannelConstraints
 
-	keyRing := keychain.NewWalletKeyRing(
+	keyRing := dcrwallet.NewWalletKeyRing(
 		wc.InternalWallet(),
 	)
 	cc.keyRing = keyRing

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -177,6 +177,7 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 		FeeEstimator:   cc.feeEstimator,
 		Wallet:         wallet,
 		Loader:         loader,
+		DB:             chanDB,
 	}
 
 	var (
@@ -315,14 +316,10 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 	cc.signer = wc
 	cc.chainIO = chainIO
 	cc.wc = wc
+	cc.keyRing = wc
 
 	// Select the default channel constraints for the primary chain.
 	channelConstraints := defaultDcrChannelConstraints
-
-	keyRing := dcrwallet.NewWalletKeyRing(
-		wc.InternalWallet(),
-	)
-	cc.keyRing = keyRing
 
 	// Create, and start the lnwallet, which handles the core payment
 	// channel logic, and exposes control via proxy state machines.
@@ -332,7 +329,7 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 		WalletController:   wc,
 		Signer:             cc.signer,
 		FeeEstimator:       cc.feeEstimator,
-		SecretKeyRing:      keyRing,
+		SecretKeyRing:      wc,
 		ChainIO:            cc.chainIO,
 		DefaultConstraints: channelConstraints,
 		NetParams:          *activeNetParams.Params,

--- a/channeldb/keychain.go
+++ b/channeldb/keychain.go
@@ -1,0 +1,99 @@
+package channeldb
+
+import (
+	"errors"
+	bolt "go.etcd.io/bbolt"
+)
+
+const (
+	// lastUsableKeyFamily is the last key family index that can be stored
+	// by the database. This value matches the last account number that can
+	// be used to create an account in HD wallets, assuming accounts are
+	// created as hardened branches.
+	lastUsableKeyFamily = 0x7fffffff
+
+	// lastUsableFamilyIndex is the last index that can be returned by a
+	// given key family.
+	lastUsableKeyFamilyIndex = 0x7fffffff
+)
+
+var (
+	// errInvalidKeyFamily is returned when an invalid key family is
+	// requested.
+	errInvalidKeyFamily = errors.New("invalid key family")
+
+	// errKeyFamilyExchausted is returned when a given keyfamily has
+	// generated enough indexes that no more can be generated.
+	errKeyFamilyExhausted = errors.New("keyfamily indexes exhausted")
+
+	// keychainBucket is the root bucket used to store keychain/keyring
+	// data.
+	keychainBucket = []byte("keychain")
+
+	// keyFamilyIndexesBucket is the bucket used to store the current index
+	// of each requested key famiy.
+	//
+	// Keys are byte-ordered uint32 slices, and values are byte-ordered
+	// uint32 values that represent the last returned index for a family.
+	keyFamilyIndexesBucket = []byte("kfidxs")
+)
+
+// NextFamilyIndex returns the next index for a given family of keys from the
+// database-backed keyring.
+//
+// A _KeyFamily_ is an uint32 that maps to the key families of the keychain
+// package, while the returned index can be considered the index of a
+// (possibly) unused key.
+//
+// Repeated calls to NextKeyFamilyIndex will return different values. This
+// function errors if the requested family would create an invalid HD extended
+// key or if it the key family has been exhausted and no more keys can be
+// generated for it.
+func (d *DB) NextKeyFamilyIndex(keyFamily uint32) (uint32, error) {
+	var index uint32
+
+	// Key families higher than this limit would cause a numeric overflow
+	// due to accounts using hardened HD branches.
+	if keyFamily > lastUsableKeyFamily {
+		return 0, errInvalidKeyFamily
+	}
+
+	err := d.Update(func(tx *bolt.Tx) error {
+		keychain, err := tx.CreateBucketIfNotExists(keychainBucket)
+		if err != nil {
+			return err
+		}
+
+		keyFamilies, err := keychain.CreateBucketIfNotExists(
+			keyFamilyIndexesBucket,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Attempt to read the existing value for the given family.
+		var k [4]byte
+		var v [4]byte
+		byteOrder.PutUint32(k[:], keyFamily)
+		oldv := keyFamilies.Get(k[:])
+
+		// If there is a value, decode it to get the next usable index.
+		if len(oldv) == 4 {
+			index = byteOrder.Uint32(oldv)
+
+			// If we've passed the usable range for this keyfamily,
+			// return an error.
+			if index >= lastUsableKeyFamilyIndex {
+				return errKeyFamilyExhausted
+			}
+		}
+
+		// Update the database with the next usable index.
+		byteOrder.PutUint32(v[:], index+1)
+		keyFamilies.Put(k[:], v[:])
+
+		return nil
+	})
+
+	return index, err
+}

--- a/channeldb/keychain_test.go
+++ b/channeldb/keychain_test.go
@@ -1,0 +1,87 @@
+package channeldb
+
+import (
+	"testing"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// TestSaneNextKeyFamilyIndex tests that the generation of key family indices
+// is sane and follows the propper semantics.
+func TestSaneNextKeyFamilyIndex(t *testing.T) {
+	t.Parallel()
+
+	db, cleanUp, err := makeTestDB()
+	defer cleanUp()
+	if err != nil {
+		t.Fatalf("unable to make test db: %v", err)
+	}
+
+	// Two consecutive calls should generate different indices for the same
+	// key family.
+	i1, err := db.NextKeyFamilyIndex(0)
+	if err != nil {
+		t.Fatalf("unable to generate first index: %v", err)
+	}
+
+	if i1 != 0 {
+		t.Fatalf("the first returned index should be 0")
+	}
+
+	i2, err := db.NextKeyFamilyIndex(0)
+	if err != nil {
+		t.Fatalf("unable to generate second index: %v", err)
+	}
+	if i2 != 1 {
+		t.Fatalf("the second returned index should be 1")
+	}
+
+	// Generating for a new key family should return the first index again.
+	i3, err := db.NextKeyFamilyIndex(1)
+	if err != nil {
+		t.Fatalf("unable to generate index for second family: %v", err)
+	}
+	if i3 != 0 {
+		t.Fatalf("the index for the second family should be 0")
+	}
+
+	// Trying to generate an index for an invalid family should return an
+	// error.
+	_, err = db.NextKeyFamilyIndex(0x80000000)
+	if err != errInvalidKeyFamily {
+		t.Fatalf("invalid family should return correct error; got %v",
+			err)
+	}
+
+	// Manually change the db to simulate exhausting a key family
+	err = db.Update(func(tx *bolt.Tx) error {
+		keychain, err := tx.CreateBucketIfNotExists(keychainBucket)
+		if err != nil {
+			return err
+		}
+
+		keyFamilies, err := keychain.CreateBucketIfNotExists(
+			keyFamilyIndexesBucket,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Write the maximum usable index to the keyFamily 0
+		var k [4]byte
+		var v [4]byte
+		byteOrder.PutUint32(v[:], 0x7fffffff)
+		keyFamilies.Put(k[:], v[:])
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unable to manipulate db: %v", err)
+	}
+
+	// Try to generate the next index. It should fail.
+	_, err = db.NextKeyFamilyIndex(0)
+	if err != errKeyFamilyExhausted {
+		t.Fatalf("exhausted family should return correct error; got %v",
+			err)
+	}
+}

--- a/keychain/derivation.go
+++ b/keychain/derivation.go
@@ -24,6 +24,16 @@ const (
 	BIP0043Purpose = 1017
 )
 
+const (
+	// CoinTypeDecred specifies the BIP44 coin type for Decred key
+	// derivation.
+	CoinTypeDecred uint32 = 42
+
+	// CoinTypeTestnet specifies the BIP44 coin
+	// type for all testnet key derivation.
+	CoinTypeTestnet = 1
+)
+
 var (
 	// MaxKeyRangeScan is the maximum number of keys that we'll attempt to
 	// scan with if a caller knows the public key, but not the KeyLocator

--- a/keychain/hdkeyring.go
+++ b/keychain/hdkeyring.go
@@ -1,0 +1,201 @@
+package keychain
+
+import (
+	"crypto/sha256"
+	"errors"
+
+	"github.com/decred/dcrd/dcrec/secp256k1"
+	"github.com/decred/dcrd/hdkeychain"
+)
+
+var errPubOnlyKeyRing = errors.New("keyring configured as pubkey only")
+
+// HDKeyRing is an implementation of both the KeyRing and SecretKeyRing
+// interfaces backed by a root master key pair. The master extended public keys
+// (one for each required key family) is maintained in memory at all times,
+// while the extended private key must be produred by a function (specified
+// during struct setup) whenever requested.
+type HDKeyRing struct {
+	masterPubs      map[KeyFamily]*hdkeychain.ExtendedKey
+	fetchMasterPriv func(KeyFamily) (*hdkeychain.ExtendedKey, error)
+	nextIndex       func(KeyFamily) (uint32, error)
+}
+
+// Compile time type assertions to ensure HDKeyRing fulfills the desired
+// interfaces.
+var _ KeyRing = (*HDKeyRing)(nil)
+var _ SecretKeyRing = (*HDKeyRing)(nil)
+
+// NewHDKeyRing creates a new implementation of the keychain.SecretKeyRing
+// interface backed by a set of extended HD keys.
+//
+// The passed fetchMasterPriv must be able to return the master private key for
+// the keyring in a timely fashion, otherwise sign operations may be delayed.
+// If this function is not specified, then the KeyRing cannot derive private
+// keys.
+//
+// The passed nextIndex must be able to return the next (unused) index for each
+// existing KeyFamily used in ln operations. Indication that the index was
+// returned should be persisted in some way, such that public key reuse is
+// minimized and the same index is not returned twice. In other words, calling
+// nextAddrIndex twice should return different values, otherwise key derivation
+// might hang forever.
+//
+// If either the set of master public keys (one for each family) or the next
+// address index are not provided, the results from trying to use this function
+// are undefined.
+func NewHDKeyRing(masterPubs map[KeyFamily]*hdkeychain.ExtendedKey,
+	fetchMasterPriv func(KeyFamily) (*hdkeychain.ExtendedKey, error),
+	nextIndex func(KeyFamily) (uint32, error)) *HDKeyRing {
+
+	return &HDKeyRing{
+		masterPubs:      masterPubs,
+		fetchMasterPriv: fetchMasterPriv,
+		nextIndex:       nextIndex,
+	}
+}
+
+// DeriveNextKey attempts to derive the *next* key within the key family
+// (account in BIP43) specified. This method should return the next external
+// child within this branch.
+//
+// NOTE: This is part of the keychain.KeyRing interface.
+func (kr *HDKeyRing) DeriveNextKey(keyFam KeyFamily) (KeyDescriptor, error) {
+
+	masterPub := kr.masterPubs[keyFam]
+
+	for {
+		// Derive the key and skip to next if invalid.
+		index, err := kr.nextIndex(keyFam)
+		if err != nil {
+			return KeyDescriptor{}, err
+		}
+		indexKey, err := masterPub.Child(index)
+
+		if err == hdkeychain.ErrInvalidChild {
+			continue
+		}
+		if err != nil {
+			return KeyDescriptor{}, err
+		}
+
+		pubkey, err := indexKey.ECPubKey()
+		if err != nil {
+			return KeyDescriptor{}, err
+		}
+
+		return KeyDescriptor{
+			PubKey: pubkey,
+			KeyLocator: KeyLocator{
+				Family: keyFam,
+				Index:  index,
+			},
+		}, nil
+	}
+}
+
+// DeriveKey attempts to derive an arbitrary key specified by the passed
+// KeyLocator. This may be used in several recovery scenarios, or when manually
+// rotating something like our current default node key.
+//
+// NOTE: This is part of the keychain.KeyRing interface.
+func (kr HDKeyRing) DeriveKey(keyLoc KeyLocator) (KeyDescriptor, error) {
+	masterPub := kr.masterPubs[keyLoc.Family]
+	key, err := masterPub.Child(keyLoc.Index)
+	if err != nil {
+		return KeyDescriptor{}, err
+	}
+	pubKey, err := key.ECPubKey()
+	if err != nil {
+		return KeyDescriptor{}, err
+	}
+
+	return KeyDescriptor{
+		KeyLocator: keyLoc,
+		PubKey:     pubKey,
+	}, nil
+}
+
+// DerivePrivKey attempts to derive the private key that corresponds to the
+// passed key descriptor.
+//
+// NOTE: This is part of the keychain.SecretKeyRing interface.
+func (kr *HDKeyRing) DerivePrivKey(keyDesc KeyDescriptor) (*secp256k1.PrivateKey, error) {
+
+	if kr.fetchMasterPriv == nil {
+		return nil, errPubOnlyKeyRing
+	}
+
+	// We'll grab the master pub key for the provided account (family) then
+	// manually derive the addresses here.
+	masterPriv, err := kr.fetchMasterPriv(keyDesc.Family)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the public key isn't set or they have a non-zero index,
+	// then we know that the caller instead knows the derivation
+	// path for a key.
+	if keyDesc.PubKey == nil || keyDesc.Index > 0 {
+		privKey, err := masterPriv.Child(keyDesc.Index)
+		if err != nil {
+			return nil, err
+		}
+		return privKey.ECPrivKey()
+	}
+
+	// If the public key isn't nil, then this indicates that we
+	// need to scan for the private key, assuming that we know the
+	// valid key family.
+	for i := 0; i < MaxKeyRangeScan; i++ {
+		// Derive the next key in the range and fetch its
+		// managed address.
+		privKey, err := masterPriv.Child(uint32(i))
+		if err == hdkeychain.ErrInvalidChild {
+			continue
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		pubKey, err := privKey.ECPubKey()
+		if err != nil {
+			// simply skip invalid keys here
+			continue
+		}
+
+		if keyDesc.PubKey.IsEqual(pubKey) {
+			return privKey.ECPrivKey()
+		}
+	}
+
+	return nil, ErrCannotDerivePrivKey
+}
+
+// ScalarMult performs a scalar multiplication (ECDH-like operation) between
+// the target key descriptor and remote public key. The output returned will be
+// the sha256 of the resulting shared point serialized in compressed format. If
+// k is our private key, and P is the public key, we perform the following
+// operation:
+//
+//  sx := k*P s := sha256(sx.SerializeCompressed())
+//
+// NOTE: This is part of the keychain.SecretKeyRing interface.
+func (kr *HDKeyRing) ScalarMult(keyDesc KeyDescriptor,
+	pub *secp256k1.PublicKey) ([]byte, error) {
+
+	privKey, err := kr.DerivePrivKey(keyDesc)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &secp256k1.PublicKey{}
+	x, y := secp256k1.S256().ScalarMult(pub.X, pub.Y, privKey.D.Bytes())
+	s.X = x
+	s.Y = y
+
+	h := sha256.Sum256(s.SerializeCompressed())
+
+	return h[:], nil
+}

--- a/keychain/hdkeyring_test.go
+++ b/keychain/hdkeyring_test.go
@@ -1,0 +1,77 @@
+package keychain
+
+import (
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/hdkeychain"
+)
+
+var (
+	testHDSeed = chainhash.Hash{
+		0xb7, 0x94, 0x38, 0x5f, 0x2d, 0x1e, 0xf7, 0xab,
+		0x4d, 0x92, 0x73, 0xd1, 0x90, 0x63, 0x81, 0xb4,
+		0x4f, 0x2f, 0x6f, 0x25, 0x98, 0xa3, 0xef, 0xb9,
+		0x69, 0x49, 0x18, 0x83, 0x31, 0x98, 0x47, 0x53,
+	}
+)
+
+// createTestHDKeyRing creates a test HDKeyRing implementation that works
+// purely in memory, using the default test HD seed as root master private key.
+func createTestHDKeyRing() *HDKeyRing {
+	// We can ignore errors here because they could only be for invalid
+	// keys/seeds and the default test seed does not produce errors.
+	master, _ := hdkeychain.NewMaster(testHDSeed[:], &chaincfg.RegNetParams)
+	masterPubs := make(map[KeyFamily]*hdkeychain.ExtendedKey,
+		len(versionZeroKeyFamilies))
+	indexes := make(map[KeyFamily]uint32, len(versionZeroKeyFamilies))
+	for _, keyFam := range versionZeroKeyFamilies {
+		masterPubs[keyFam], _ = master.Child(uint32(keyFam))
+		indexes[keyFam] = 0
+	}
+
+	fetchMasterPriv := func(keyFam KeyFamily) (*hdkeychain.ExtendedKey, error) {
+		// We never neutered the keys in masterPubs, so they also
+		// contain the private key.
+		return masterPubs[keyFam], nil
+	}
+
+	nextIndex := func(keyFam KeyFamily) (uint32, error) {
+		index := indexes[keyFam]
+		indexes[keyFam] += 1
+		return index, nil
+	}
+
+	return NewHDKeyRing(masterPubs, fetchMasterPriv, nextIndex)
+}
+
+// TestHDKeyRingImpl tests whether the HDKeyRing implementation conforms to the
+// required interface spec.
+func TestHDKeyRingImpl(t *testing.T) {
+	t.Parallel()
+
+	CheckKeyRingImpl(t,
+		func() (string, func(), KeyRing, error) {
+			return "hdkeyring", func() {}, createTestHDKeyRing(), nil
+		},
+	)
+}
+
+// TestHDSecretKeyRingImpl tests whether the HDKeyRing implementation conforms
+// to the required interface spec.
+func TestHDSecretKeyRingImpl(t *testing.T) {
+	t.Parallel()
+
+	CheckSecretKeyRingImpl(t,
+		func() (string, func(), SecretKeyRing, error) {
+			return "hdkeyring", func() {}, createTestHDKeyRing(), nil
+		},
+	)
+}
+
+func init() {
+	// We'll clamp the max range scan to constrain the run time of the
+	// private key scan test.
+	MaxKeyRangeScan = 3
+}

--- a/keychain/interface_test.go
+++ b/keychain/interface_test.go
@@ -133,6 +133,18 @@ func TestKeyRingDerivation(t *testing.T) {
 					}, keyDesc.KeyLocator,
 				)
 
+				// We'll generate the next key and ensure it's
+				// different than the first one.
+				keyDescNext, err := keyRing.DeriveNextKey(keyFam)
+				if err != nil {
+					t.Fatalf("unable to derive next for"+
+						"keyFam=%v: %v", keyFam, err)
+				}
+				if keyDescNext.PubKey.IsEqual(keyDesc.PubKey) {
+					t.Fatal("keyring derived two " +
+						"identical consecutive keys")
+				}
+
 				// We'll now re-derive that key to ensure that
 				// we're able to properly access the key via
 				// the random access derivation methods.

--- a/keychain/interface_test.go
+++ b/keychain/interface_test.go
@@ -1,7 +1,6 @@
 package keychain
 
 import (
-	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -108,18 +107,142 @@ func assertEqualKeyLocator(t *testing.T, a, b KeyLocator) {
 	}
 }
 
-// secretKeyRingConstructor is a function signature that's used as a generic
+// KeyRingConstructor is a function signature that's used as a generic
 // constructor for various implementations of the KeyRing interface. A string
 // naming the returned interface, a function closure that cleans up any
 // resources, and the clean up interface itself are to be returned.
-type keyRingConstructor func() (string, func(), KeyRing, error)
+type KeyRingConstructor func() (string, func(), KeyRing, error)
 
-// TestKeyRingDerivation tests that each known KeyRing implementation properly
+// CheckKeyRingImpl tests that the provided KeyRing implementation properly
 // adheres to the expected behavior of the set of interfaces.
-func TestKeyRingDerivation(t *testing.T) {
+func CheckKeyRingImpl(t *testing.T, constructor KeyRingConstructor) {
+	const numKeysToDerive = 10
+
+	// For each implementation constructor, we'll execute an identical set
+	// of tests in order to ensure that the interface adheres to our
+	// nominal specification.
+	keyRingName, cleanUp, keyRing, err := constructor()
+	if err != nil {
+		t.Fatalf("unable to create key ring %v: %v", keyRingName,
+			err)
+	}
+	defer cleanUp()
+
+	// First, we'll ensure that we're able to derive keys from each
+	// of the known key families.
+	for _, keyFam := range versionZeroKeyFamilies {
+		// First, we'll ensure that we can derive the
+		// *next* key in the keychain.
+		keyDesc, err := keyRing.DeriveNextKey(keyFam)
+		if err != nil {
+			t.Fatalf("unable to derive next for "+
+				"keyFam=%v: %v", keyFam, err)
+		}
+		assertEqualKeyLocator(t,
+			KeyLocator{
+				Family: keyFam,
+				Index:  0,
+			}, keyDesc.KeyLocator,
+		)
+
+		// We'll generate the next key and ensure it's
+		// different than the first one.
+		keyDescNext, err := keyRing.DeriveNextKey(keyFam)
+		if err != nil {
+			t.Fatalf("unable to derive next for"+
+				"keyFam=%v: %v", keyFam, err)
+		}
+		if keyDescNext.PubKey.IsEqual(keyDesc.PubKey) {
+			t.Fatal("keyring derived two " +
+				"identical consecutive keys")
+		}
+
+		// We'll now re-derive that key to ensure that
+		// we're able to properly access the key via
+		// the random access derivation methods.
+		keyLoc := KeyLocator{
+			Family: keyFam,
+			Index:  0,
+		}
+		firstKeyDesc, err := keyRing.DeriveKey(keyLoc)
+		if err != nil {
+			t.Fatalf("unable to derive first key for "+
+				"keyFam=%v: %v", keyFam, err)
+		}
+		if !keyDesc.PubKey.IsEqual(firstKeyDesc.PubKey) {
+			t.Fatalf("mismatched keys: expected %x, "+
+				"got %x",
+				keyDesc.PubKey.SerializeCompressed(),
+				firstKeyDesc.PubKey.SerializeCompressed())
+		}
+		assertEqualKeyLocator(t,
+			KeyLocator{
+				Family: keyFam,
+				Index:  0,
+			}, firstKeyDesc.KeyLocator,
+		)
+
+		// If we now try to manually derive the next 10
+		// keys (including the original key), then we
+		// should get an identical public key back and
+		// their KeyLocator information
+		// should be set properly.
+		for i := 0; i < numKeysToDerive+1; i++ {
+			keyLoc := KeyLocator{
+				Family: keyFam,
+				Index:  uint32(i),
+			}
+			keyDesc, err := keyRing.DeriveKey(keyLoc)
+			if err != nil {
+				t.Fatalf("unable to derive first key for "+
+					"keyFam=%v: %v", keyFam, err)
+			}
+
+			// Ensure that the key locator matches
+			// up as well.
+			assertEqualKeyLocator(
+				t, keyLoc, keyDesc.KeyLocator,
+			)
+		}
+
+		// If this succeeds, then we'll also try to
+		// derive a random index within the range.
+		randKeyIndex := uint32(rand.Int31())
+		keyLoc = KeyLocator{
+			Family: keyFam,
+			Index:  randKeyIndex,
+		}
+		keyDesc, err = keyRing.DeriveKey(keyLoc)
+		if err != nil {
+			t.Fatalf("unable to derive key_index=%v "+
+				"for keyFam=%v: %v",
+				randKeyIndex, keyFam, err)
+		}
+		assertEqualKeyLocator(
+			t, keyLoc, keyDesc.KeyLocator,
+		)
+	}
+
+}
+
+// TestHDKeyRingImpl tests whether the HDKeyRing implementation conforms to the
+// required interface spec.
+func TestHDKeyRingImpl(t *testing.T) {
 	t.Parallel()
 
-	keyRingImplementations := []keyRingConstructor{
+	CheckKeyRingImpl(t,
+		func() (string, func(), KeyRing, error) {
+			return "hdkeyring", func() {}, createTestHDKeyRing(), nil
+		},
+	)
+}
+
+// TestDcrwalletKeyRingImpl tests whether the WalletKeyRing implementation
+// conforms to the required interface spec.
+func TestDcrwalletKeyRingImpl(t *testing.T) {
+	t.Parallel()
+
+	CheckKeyRingImpl(t,
 		func() (string, func(), KeyRing, error) {
 			cleanUp, wallet, err := createTestWallet()
 			if err != nil {
@@ -130,139 +253,142 @@ func TestKeyRingDerivation(t *testing.T) {
 
 			return "dcrwallet", cleanUp, keyRing, nil
 		},
-		func() (string, func(), KeyRing, error) {
-			return "hdkeyring", func() {}, createTestHDKeyRing(), nil
-		},
-	}
+	)
 
-	const numKeysToDerive = 10
-
-	// For each implementation constructor registered above, we'll execute
-	// an identical set of tests in order to ensure that the interface
-	// adheres to our nominal specification.
-	for _, keyRingConstructor := range keyRingImplementations {
-		keyRingName, cleanUp, keyRing, err := keyRingConstructor()
-		if err != nil {
-			t.Fatalf("unable to create key ring %v: %v", keyRingName,
-				err)
-		}
-		defer cleanUp()
-
-		success := t.Run(fmt.Sprintf("%v", keyRingName), func(t *testing.T) {
-			// First, we'll ensure that we're able to derive keys
-			// from each of the known key families.
-			for _, keyFam := range versionZeroKeyFamilies {
-				// First, we'll ensure that we can derive the
-				// *next* key in the keychain.
-				keyDesc, err := keyRing.DeriveNextKey(keyFam)
-				if err != nil {
-					t.Fatalf("unable to derive next for "+
-						"keyFam=%v: %v", keyFam, err)
-				}
-				assertEqualKeyLocator(t,
-					KeyLocator{
-						Family: keyFam,
-						Index:  0,
-					}, keyDesc.KeyLocator,
-				)
-
-				// We'll generate the next key and ensure it's
-				// different than the first one.
-				keyDescNext, err := keyRing.DeriveNextKey(keyFam)
-				if err != nil {
-					t.Fatalf("unable to derive next for"+
-						"keyFam=%v: %v", keyFam, err)
-				}
-				if keyDescNext.PubKey.IsEqual(keyDesc.PubKey) {
-					t.Fatal("keyring derived two " +
-						"identical consecutive keys")
-				}
-
-				// We'll now re-derive that key to ensure that
-				// we're able to properly access the key via
-				// the random access derivation methods.
-				keyLoc := KeyLocator{
-					Family: keyFam,
-					Index:  0,
-				}
-				firstKeyDesc, err := keyRing.DeriveKey(keyLoc)
-				if err != nil {
-					t.Fatalf("unable to derive first key for "+
-						"keyFam=%v: %v", keyFam, err)
-				}
-				if !keyDesc.PubKey.IsEqual(firstKeyDesc.PubKey) {
-					t.Fatalf("mismatched keys: expected %x, "+
-						"got %x",
-						keyDesc.PubKey.SerializeCompressed(),
-						firstKeyDesc.PubKey.SerializeCompressed())
-				}
-				assertEqualKeyLocator(t,
-					KeyLocator{
-						Family: keyFam,
-						Index:  0,
-					}, firstKeyDesc.KeyLocator,
-				)
-
-				// If we now try to manually derive the next 10
-				// keys (including the original key), then we
-				// should get an identical public key back and
-				// their KeyLocator information
-				// should be set properly.
-				for i := 0; i < numKeysToDerive+1; i++ {
-					keyLoc := KeyLocator{
-						Family: keyFam,
-						Index:  uint32(i),
-					}
-					keyDesc, err := keyRing.DeriveKey(keyLoc)
-					if err != nil {
-						t.Fatalf("unable to derive first key for "+
-							"keyFam=%v: %v", keyFam, err)
-					}
-
-					// Ensure that the key locator matches
-					// up as well.
-					assertEqualKeyLocator(
-						t, keyLoc, keyDesc.KeyLocator,
-					)
-				}
-
-				// If this succeeds, then we'll also try to
-				// derive a random index within the range.
-				randKeyIndex := uint32(rand.Int31())
-				keyLoc = KeyLocator{
-					Family: keyFam,
-					Index:  randKeyIndex,
-				}
-				keyDesc, err = keyRing.DeriveKey(keyLoc)
-				if err != nil {
-					t.Fatalf("unable to derive key_index=%v "+
-						"for keyFam=%v: %v",
-						randKeyIndex, keyFam, err)
-				}
-				assertEqualKeyLocator(
-					t, keyLoc, keyDesc.KeyLocator,
-				)
-			}
-		})
-		if !success {
-			break
-		}
-	}
 }
 
-// secretKeyRingConstructor is a function signature that's used as a generic
+// SecretKeyRingConstructor is a function signature that's used as a generic
 // constructor for various implementations of the SecretKeyRing interface. A
 // string naming the returned interface, a function closure that cleans up any
 // resources, and the clean up interface itself are to be returned.
-type secretKeyRingConstructor func() (string, func(), SecretKeyRing, error)
+type SecretKeyRingConstructor func() (string, func(), SecretKeyRing, error)
 
 // TestSecretKeyRingDerivation tests that each known SecretKeyRing
 // implementation properly adheres to the expected behavior of the set of
 // interface.
-func TestSecretKeyRingDerivation(t *testing.T) {
+func CheckSecretKeyRingImpl(t *testing.T, constructor SecretKeyRingConstructor) {
+
+	// For each implementation constructor, we'll execute an identical set
+	// of tests in order to ensure that the interface adheres to our
+	// nominal specification.
+	keyRingName, cleanUp, secretKeyRing, err := constructor()
+	if err != nil {
+		t.Fatalf("unable to create secret key ring %v: %v",
+			keyRingName, err)
+	}
+	defer cleanUp()
+
+	// For, each key family, we'll ensure that we're able to obtain
+	// the private key of a randomly select child index within the
+	// key family.
+	for _, keyFam := range versionZeroKeyFamilies {
+		randKeyIndex := uint32(rand.Int31())
+		keyLoc := KeyLocator{
+			Family: keyFam,
+			Index:  randKeyIndex,
+		}
+
+		// First, we'll query for the public key for
+		// this target key locator.
+		pubKeyDesc, err := secretKeyRing.DeriveKey(keyLoc)
+		if err != nil {
+			t.Fatalf("unable to derive pubkey "+
+				"(fam=%v, index=%v): %v",
+				keyLoc.Family,
+				keyLoc.Index, err)
+		}
+
+		// With the public key derive, ensure that
+		// we're able to obtain the corresponding
+		// private key correctly.
+		privKey, err := secretKeyRing.DerivePrivKey(KeyDescriptor{
+			KeyLocator: keyLoc,
+		})
+		if err != nil {
+			t.Fatalf("unable to derive priv "+
+				"(fam=%v, index=%v): %v", keyLoc.Family,
+				keyLoc.Index, err)
+		}
+
+		// Finally, ensure that the keys match up
+		// properly.
+		if !pubKeyDesc.PubKey.IsEqual(privKey.PubKey()) {
+			t.Fatalf("pubkeys mismatched: expected %x, got %x",
+				pubKeyDesc.PubKey.SerializeCompressed(),
+				privKey.PubKey().SerializeCompressed())
+		}
+
+		// Next, we'll test that we're able to derive a
+		// key given only the public key and key
+		// family.
+		//
+		// Derive a new key from the key ring.
+		keyDesc, err := secretKeyRing.DeriveNextKey(keyFam)
+		if err != nil {
+			t.Fatalf("unable to derive key: %v", err)
+		}
+
+		// We'll now construct a key descriptor that
+		// requires us to scan the key range, and query
+		// for the key, we should be able to find it as
+		// it's valid.
+		keyDesc = KeyDescriptor{
+			PubKey: keyDesc.PubKey,
+			KeyLocator: KeyLocator{
+				Family: keyFam,
+			},
+		}
+		privKey, err = secretKeyRing.DerivePrivKey(keyDesc)
+		if err != nil {
+			t.Fatalf("unable to derive priv key "+
+				"via scanning: %v", err)
+		}
+
+		// Having to resort to scanning, we should be
+		// able to find the target public key.
+		if !keyDesc.PubKey.IsEqual(privKey.PubKey()) {
+			t.Fatalf("pubkeys mismatched: expected %x, got %x",
+				pubKeyDesc.PubKey.SerializeCompressed(),
+				privKey.PubKey().SerializeCompressed())
+		}
+
+		// We'll try again, but this time with an
+		// unknown public key.
+		_, pub := secp256k1.PrivKeyFromBytes(testHDSeed[:])
+		keyDesc.PubKey = pub
+
+		// If we attempt to query for this key, then we
+		// should get ErrCannotDerivePrivKey.
+		_, err = secretKeyRing.DerivePrivKey(
+			keyDesc,
+		)
+		if err != ErrCannotDerivePrivKey {
+			t.Fatalf("expected %T, instead got %v",
+				ErrCannotDerivePrivKey, err)
+		}
+
+		// TODO(roasbeef): scalar mult once integrated
+	}
+}
+
+// TestHDSecretKeyRingImpl tests whether the HDKeyRing implementation conforms
+// to the required interface spec.
+func TestHDSecretKeyRingImpl(t *testing.T) {
 	t.Parallel()
 
-	secretKeyRingImplementations := []secretKeyRingConstructor{
+	CheckSecretKeyRingImpl(t,
+		func() (string, func(), SecretKeyRing, error) {
+			return "hdkeyring", func() {}, createTestHDKeyRing(), nil
+		},
+	)
+}
+
+// TestDcrwalletSecretKeyRingImpl tests whether the WalletKeyRing
+// implementation conforms to the required interface spec.
+func TestDcrwalletSecretKeyRingImpl(t *testing.T) {
+	t.Parallel()
+
+	CheckSecretKeyRingImpl(t,
 		func() (string, func(), SecretKeyRing, error) {
 			cleanUp, wallet, err := createTestWallet()
 			if err != nil {
@@ -273,119 +399,8 @@ func TestSecretKeyRingDerivation(t *testing.T) {
 
 			return "dcrwallet", cleanUp, keyRing, nil
 		},
-		func() (string, func(), SecretKeyRing, error) {
-			return "hdkeyring", func() {}, createTestHDKeyRing(), nil
-		},
-	}
+	)
 
-	// For each implementation constructor registered above, we'll execute
-	// an identical set of tests in order to ensure that the interface
-	// adheres to our nominal specification.
-	for _, secretKeyRingConstructor := range secretKeyRingImplementations {
-		keyRingName, cleanUp, secretKeyRing, err := secretKeyRingConstructor()
-		if err != nil {
-			t.Fatalf("unable to create secret key ring %v: %v",
-				keyRingName, err)
-		}
-		defer cleanUp()
-
-		success := t.Run(fmt.Sprintf("%v", keyRingName), func(t *testing.T) {
-			// For, each key family, we'll ensure that we're able
-			// to obtain the private key of a randomly select child
-			// index within the key family.
-			for _, keyFam := range versionZeroKeyFamilies {
-				randKeyIndex := uint32(rand.Int31())
-				keyLoc := KeyLocator{
-					Family: keyFam,
-					Index:  randKeyIndex,
-				}
-
-				// First, we'll query for the public key for
-				// this target key locator.
-				pubKeyDesc, err := secretKeyRing.DeriveKey(keyLoc)
-				if err != nil {
-					t.Fatalf("unable to derive pubkey "+
-						"(fam=%v, index=%v): %v",
-						keyLoc.Family,
-						keyLoc.Index, err)
-				}
-
-				// With the public key derive, ensure that
-				// we're able to obtain the corresponding
-				// private key correctly.
-				privKey, err := secretKeyRing.DerivePrivKey(KeyDescriptor{
-					KeyLocator: keyLoc,
-				})
-				if err != nil {
-					t.Fatalf("unable to derive priv "+
-						"(fam=%v, index=%v): %v", keyLoc.Family,
-						keyLoc.Index, err)
-				}
-
-				// Finally, ensure that the keys match up
-				// properly.
-				if !pubKeyDesc.PubKey.IsEqual(privKey.PubKey()) {
-					t.Fatalf("pubkeys mismatched: expected %x, got %x",
-						pubKeyDesc.PubKey.SerializeCompressed(),
-						privKey.PubKey().SerializeCompressed())
-				}
-
-				// Next, we'll test that we're able to derive a
-				// key given only the public key and key
-				// family.
-				//
-				// Derive a new key from the key ring.
-				keyDesc, err := secretKeyRing.DeriveNextKey(keyFam)
-				if err != nil {
-					t.Fatalf("unable to derive key: %v", err)
-				}
-
-				// We'll now construct a key descriptor that
-				// requires us to scan the key range, and query
-				// for the key, we should be able to find it as
-				// it's valid.
-				keyDesc = KeyDescriptor{
-					PubKey: keyDesc.PubKey,
-					KeyLocator: KeyLocator{
-						Family: keyFam,
-					},
-				}
-				privKey, err = secretKeyRing.DerivePrivKey(keyDesc)
-				if err != nil {
-					t.Fatalf("unable to derive priv key "+
-						"via scanning: %v", err)
-				}
-
-				// Having to resort to scanning, we should be
-				// able to find the target public key.
-				if !keyDesc.PubKey.IsEqual(privKey.PubKey()) {
-					t.Fatalf("pubkeys mismatched: expected %x, got %x",
-						pubKeyDesc.PubKey.SerializeCompressed(),
-						privKey.PubKey().SerializeCompressed())
-				}
-
-				// We'll try again, but this time with an
-				// unknown public key.
-				_, pub := secp256k1.PrivKeyFromBytes(testHDSeed[:])
-				keyDesc.PubKey = pub
-
-				// If we attempt to query for this key, then we
-				// should get ErrCannotDerivePrivKey.
-				_, err = secretKeyRing.DerivePrivKey(
-					keyDesc,
-				)
-				if err != ErrCannotDerivePrivKey {
-					t.Fatalf("expected %T, instead got %v",
-						ErrCannotDerivePrivKey, err)
-				}
-
-				// TODO(roasbeef): scalar mult once integrated
-			}
-		})
-		if !success {
-			break
-		}
-	}
 }
 
 func init() {

--- a/lnwallet/dcrwallet/config.go
+++ b/lnwallet/dcrwallet/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrlnd/channeldb"
 	"github.com/decred/dcrlnd/lnwallet"
 
 	walletloader "github.com/decred/dcrwallet/loader"
@@ -94,6 +95,8 @@ type Config struct {
 	// Loader is the loader used to initialize the Wallet field. If Wallet
 	// is specified, then Loader MUST be specified as well.
 	Loader *walletloader.Loader
+
+	DB *channeldb.DB
 }
 
 // NetworkDir returns the directory name of a network directory to hold wallet

--- a/lnwallet/dcrwallet/keychain.go
+++ b/lnwallet/dcrwallet/keychain.go
@@ -1,273 +1,119 @@
 package dcrwallet
 
 import (
-	"crypto/sha256"
-	"fmt"
-
+	"github.com/decred/dcrlnd/channeldb"
 	"github.com/decred/dcrlnd/keychain"
 
-	"github.com/decred/dcrd/dcrec/secp256k1"
-	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/hdkeychain"
-	"github.com/decred/dcrwallet/errors"
 	"github.com/decred/dcrwallet/wallet/v2"
 	"github.com/decred/dcrwallet/wallet/v2/udb"
 )
 
-// WalletKeyRing is an implementation of both the KeyRing and SecretKeyRing
-// interfaces backed by dcrwallet's internal root udb. Internally, we'll be
-// using a ScopedKeyManager to do all of our derivations, using the key scope
-// and scope addr scehma defined above. Re-using the existing key scope
-// construction means that all key derivation will be protected under the root
-// seed of the wallet, making each derived key fully deterministic.
-type WalletKeyRing struct {
+// walletKeyRing is an implementation of both the KeyRing and SecretKeyRing
+// interfaces backed by dcrwallet's internal root keys.
+//
+// While the wallet's root keys are used, the actual final key derivation does
+// _not_ take place in the wallet; instead it is done here. This is done so
+// that the wallet does not attempt to keep track of a large amount of keys
+// (addresses) that are meant for off-chain processes and are unlikely to ever
+// be found on-chain.
+//
+// Even though the final keys are derived here, they are currently derived
+// following a BIP0043 style path starting at the first account (account number
+// 0) and for the external branch only, which maintains compatibility with a
+// previous version of this implementation that was done entirely on the
+// wallet. Note that changing this derivation procedure means invalidating
+// existing dcrlnd wallets.
+type walletKeyRing struct {
+	*keychain.HDKeyRing
+
 	// wallet is a pointer to the active instance of the dcrwallet core.
 	// This is required as we'll need to manually open database
 	// transactions in order to derive addresses and lookup relevant keys
 	wallet *wallet.Wallet
+
+	// db is a pointer to a channeldb.DB instance that stores the indices
+	// of used keys of the keyring. This is used to track the next
+	// available key to prevent key reuse when establishing channels.
+	db *channeldb.DB
 }
 
-// NewWalletKeyRing creates a new implementation of the
-// keychain.SecretKeyRing interface backed by dcrwallet.
+// Compile time type assertions to ensure walletKeyRing fulfills the desired
+// interfaces.
+var _ keychain.KeyRing = (*walletKeyRing)(nil)
+var _ keychain.SecretKeyRing = (*walletKeyRing)(nil)
+
+// newWalletKeyRing creates a new implementation of the keychain.SecretKeyRing
+// interface backed by dcrwallet.
 //
-// NOTE: The passed udb.Manager MUST be unlocked in order for the keychain
-// to function.
-func NewWalletKeyRing(w *wallet.Wallet) keychain.SecretKeyRing {
-	return &WalletKeyRing{
+// NOTE: The passed wallet MUST be unlocked in order for the keychain to
+// function.
+func newWalletKeyRing(w *wallet.Wallet, db *channeldb.DB) (*walletKeyRing, error) {
+
+	// This assumes that there are no discontinuities within the KeyFamily
+	// constants.
+	lastKeyFam := uint32(keychain.KeyFamilyNodeKey)
+	masterPubs := make(map[keychain.KeyFamily]*hdkeychain.ExtendedKey,
+		lastKeyFam+1)
+
+	ctKey, err := w.CoinTypePrivKey()
+	if err != nil {
+		return nil, err
+	}
+
+	// Derive the master pubs for each key family. They are mapped to the
+	// external branch for each corresponding wallet account.
+	for i := uint32(0); i <= lastKeyFam; i++ {
+		// Errors here cause fatal failures due to the wallet not
+		// attempting to generate the next account.
+		acctKey, err := ctKey.Child(hdkeychain.HardenedKeyStart + i)
+		if err != nil {
+			return nil, err
+		}
+
+		branchKey, err := acctKey.Child(udb.ExternalBranch)
+		if err != nil {
+			return nil, err
+		}
+
+		branchPub, err := branchKey.Neuter()
+		if err != nil {
+			return nil, err
+		}
+
+		masterPubs[keychain.KeyFamily(i)] = branchPub
+	}
+
+	wkr := &walletKeyRing{
 		wallet: w,
+		db:     db,
 	}
+	wkr.HDKeyRing = keychain.NewHDKeyRing(masterPubs, wkr.fetchMasterPriv,
+		wkr.nextIndex)
+	return wkr, nil
 }
 
-// createAccountsUpTo creates all accounts representing key families up to (and
-// including) the provided argument.
-// TODO(decred) extremely inefficient for large keyFam. Ideally dcrwallet
-// should support using arbitrary account numbers.
-func (b *WalletKeyRing) createAccountsUpTo(keyFam keychain.KeyFamily) error {
-
-	// If this is the multi-sig key family, then we can return early as
-	// this is the default account that's created.
-	if keyFam == keychain.KeyFamilyMultiSig {
-		return nil
-	}
-
-	// Otherwise, we'll check if the account already exists, if so, we can
-	// once again bail early.
-	_, err := b.wallet.AccountName(uint32(keyFam))
-	if err == nil {
-		return nil
-	}
-
-	dcrwLog.Infof("Creating wallet accounts up to %d", keyFam)
-
-	// Figure out all uncreated accounts between 0..keyFam
-	accounts, err := b.wallet.Accounts()
-	if err != nil {
-		return nil
-	}
-	maxExistAccount := uint32(0)
-	for _, acct := range accounts.Accounts {
-		if acct.AccountNumber < uint32(keyFam) && acct.AccountNumber > maxExistAccount {
-			maxExistAccount = acct.AccountNumber
-		}
-	}
-
-	for i := maxExistAccount + 1; i <= uint32(keyFam); i++ {
-		dcrwLog.Debugf("Creating account %d", i)
-		_, err = b.wallet.NextAccount(fmt.Sprintf("%d", i))
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+func (wkr *walletKeyRing) nextIndex(keyFam keychain.KeyFamily) (uint32, error) {
+	return wkr.db.NextKeyFamilyIndex(uint32(keyFam))
 }
 
-// keyDescriptorForAddress returns the key descriptor for the given wallet
-// address. It assumes the address exists and is a P2PKH address, otherwise this
-// will error.
-func (b *WalletKeyRing) keyDescriptorForAddress(addr dcrutil.Address) (keychain.KeyDescriptor, error) {
-	var emptyKeyDesc keychain.KeyDescriptor
-	addrInfo, err := b.wallet.AddressInfo(addr)
-	if err != nil {
-		return emptyKeyDesc, err
-	}
+func (wkr *walletKeyRing) fetchMasterPriv(keyFam keychain.KeyFamily) (*hdkeychain.ExtendedKey,
+	error) {
 
-	pubAddrInfo, is := addrInfo.(udb.ManagedPubKeyAddress)
-	if !is {
-		return emptyKeyDesc, fmt.Errorf("generated address is not a ManagedPubKeyAddress")
-	}
-
-	pubKey, is := pubAddrInfo.PubKey().(*secp256k1.PublicKey)
-	if !is {
-		return emptyKeyDesc, fmt.Errorf("generated address is not a secp256k1 address")
-	}
-
-	return keychain.KeyDescriptor{
-		PubKey: pubKey,
-		KeyLocator: keychain.KeyLocator{
-			Family: keychain.KeyFamily(pubAddrInfo.Account()),
-			Index:  pubAddrInfo.Index(),
-		},
-	}, nil
-}
-
-// DeriveNextKey attempts to derive the *next* key within the key family
-// (account in BIP43) specified. This method should return the next external
-// child within this branch.
-//
-// NOTE: This is part of the keychain.KeyRing interface.
-func (b *WalletKeyRing) DeriveNextKey(keyFam keychain.KeyFamily) (keychain.KeyDescriptor, error) {
-	var (
-		addr         dcrutil.Address
-		err          error
-		emptyKeyDesc keychain.KeyDescriptor
-	)
-
-	err = b.createAccountsUpTo(keyFam)
-	if err != nil {
-		return emptyKeyDesc, err
-	}
-
-	// TODO(decred) Confirm use of gapPolicyIgnore
-	addr, err = b.wallet.NewExternalAddress(uint32(keyFam), wallet.WithGapPolicyIgnore())
-	if err != nil && errors.Is(errors.NotExist, err) {
-		// Account corresponding to this family does not exist. Create it.
-		err = b.createAccountsUpTo(keyFam)
-		if err != nil {
-			return emptyKeyDesc, err
-		}
-
-		// And re-derive the next address for it.
-		addr, err = b.wallet.NewExternalAddress(uint32(keyFam), wallet.WithGapPolicyIgnore())
-		if err != nil {
-			return emptyKeyDesc, err
-		}
-	}
-
-	return b.keyDescriptorForAddress(addr)
-}
-
-// DeriveKey attempts to derive an arbitrary key specified by the passed
-// KeyLocator. This may be used in several recovery scenarios, or when manually
-// rotating something like our current default node key.
-//
-// NOTE: This is part of the keychain.KeyRing interface.
-func (b *WalletKeyRing) DeriveKey(keyLoc keychain.KeyLocator) (keychain.KeyDescriptor, error) {
-	var emptyKeyDesc keychain.KeyDescriptor
-
-	err := b.createAccountsUpTo(keyLoc.Family)
-	if err != nil {
-		return emptyKeyDesc, err
-	}
-
-	famMasterPub, err := b.wallet.MasterPubKey(uint32(keyLoc.Family))
-	if err != nil {
-		return emptyKeyDesc, err
-	}
-	branchMasterPub, err := famMasterPub.Child(udb.ExternalBranch)
-	if err != nil {
-		return emptyKeyDesc, err
-	}
-	key, err := branchMasterPub.Child(keyLoc.Index)
-	if err != nil {
-		return emptyKeyDesc, err
-	}
-	pubKey, err := key.ECPubKey()
-	if err != nil {
-		return emptyKeyDesc, err
-	}
-
-	return keychain.KeyDescriptor{
-		KeyLocator: keyLoc,
-		PubKey:     pubKey,
-	}, nil
-}
-
-// DerivePrivKey attempts to derive the private key that corresponds to the
-// passed key descriptor.
-//
-// NOTE: This is part of the keychain.SecretKeyRing interface.
-func (b *WalletKeyRing) DerivePrivKey(keyDesc keychain.KeyDescriptor) (*secp256k1.PrivateKey, error) {
-
-	err := b.createAccountsUpTo(keyDesc.Family)
+	ctKey, err := wkr.wallet.CoinTypePrivKey()
 	if err != nil {
 		return nil, err
 	}
 
-	// We'll grab the master pub key for the provided account (family) then
-	// manually derive the addresses here.
-	famMasterPriv, err := b.wallet.MasterPrivKey(uint32(keyDesc.Family))
-	if err != nil {
-		return nil, err
-	}
-	famBranchPriv, err := famMasterPriv.Child(udb.ExternalBranch)
+	acctKey, err := ctKey.Child(hdkeychain.HardenedKeyStart + uint32(keyFam))
 	if err != nil {
 		return nil, err
 	}
 
-	// If the public key isn't set or they have a non-zero index,
-	// then we know that the caller instead knows the derivation
-	// path for a key.
-	if keyDesc.PubKey == nil || keyDesc.Index > 0 {
-		privKey, err := famBranchPriv.Child(keyDesc.Index)
-		if err != nil {
-			return nil, err
-		}
-		return privKey.ECPrivKey()
-	}
-
-	// If the public key isn't nil, then this indicates that we
-	// need to scan for the private key, assuming that we know the
-	// valid key family.
-	for i := 0; i < keychain.MaxKeyRangeScan; i++ {
-		// Derive the next key in the range and fetch its
-		// managed address.
-		privKey, err := famBranchPriv.Child(uint32(i))
-		if err == hdkeychain.ErrInvalidChild {
-			continue
-		}
-
-		if err != nil {
-			return nil, err
-		}
-
-		pubKey, err := privKey.ECPubKey()
-		if err != nil {
-			// simply skip invalid keys here
-			continue
-		}
-
-		if keyDesc.PubKey.IsEqual(pubKey) {
-			return privKey.ECPrivKey()
-		}
-	}
-
-	return nil, keychain.ErrCannotDerivePrivKey
-}
-
-// ScalarMult performs a scalar multiplication (ECDH-like operation) between
-// the target key descriptor and remote public key. The output returned will be
-// the sha256 of the resulting shared point serialized in compressed format. If
-// k is our private key, and P is the public key, we perform the following
-// operation:
-//
-//  sx := k*P s := sha256(sx.SerializeCompressed())
-//
-// NOTE: This is part of the keychain.SecretKeyRing interface.
-func (b *WalletKeyRing) ScalarMult(keyDesc keychain.KeyDescriptor,
-	pub *secp256k1.PublicKey) ([]byte, error) {
-
-	privKey, err := b.DerivePrivKey(keyDesc)
+	branchKey, err := acctKey.Child(udb.ExternalBranch)
 	if err != nil {
 		return nil, err
 	}
 
-	s := &secp256k1.PublicKey{}
-	x, y := secp256k1.S256().ScalarMult(pub.X, pub.Y, privKey.D.Bytes())
-	s.X = x
-	s.Y = y
-
-	h := sha256.Sum256(s.SerializeCompressed())
-
-	return h[:], nil
+	return branchKey, nil
 }

--- a/lnwallet/dcrwallet/keychain_test.go
+++ b/lnwallet/dcrwallet/keychain_test.go
@@ -1,0 +1,100 @@
+package dcrwallet
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrlnd/keychain"
+	walletloader "github.com/decred/dcrwallet/loader"
+	wallet "github.com/decred/dcrwallet/wallet/v2"
+	"github.com/decred/dcrwallet/wallet/v2/txrules"
+)
+
+var (
+	testHDSeed = chainhash.Hash{
+		0xb7, 0x94, 0x38, 0x5f, 0x2d, 0x1e, 0xf7, 0xab,
+		0x4d, 0x92, 0x73, 0xd1, 0x90, 0x63, 0x81, 0xb4,
+		0x4f, 0x2f, 0x6f, 0x25, 0x98, 0xa3, 0xef, 0xb9,
+		0x69, 0x49, 0x18, 0x83, 0x31, 0x98, 0x47, 0x53,
+	}
+)
+
+func createTestWallet() (func(), *wallet.Wallet, error) {
+	tempDir, err := ioutil.TempDir("", "keyring-lnwallet")
+	if err != nil {
+		return nil, nil, err
+	}
+	loader := walletloader.NewLoader(&chaincfg.RegNetParams, tempDir,
+		&walletloader.StakeOptions{}, wallet.DefaultGapLimit, false,
+		txrules.DefaultRelayFeePerKb.ToCoin(), wallet.DefaultAccountGapLimit,
+		false)
+
+	pass := []byte("test")
+
+	baseWallet, err := loader.CreateNewWallet(
+		pass, pass, testHDSeed[:],
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := baseWallet.Unlock(pass, nil); err != nil {
+		return nil, nil, err
+	}
+
+	cleanUp := func() {
+		baseWallet.Lock()
+		os.RemoveAll(tempDir)
+	}
+
+	return cleanUp, baseWallet, nil
+}
+
+// TestDcrwalletKeyRingImpl tests whether the WalletKeyRing implementation
+// conforms to the required interface spec.
+func TestDcrwalletKeyRingImpl(t *testing.T) {
+	t.Parallel()
+
+	keychain.CheckKeyRingImpl(t,
+		func() (string, func(), keychain.KeyRing, error) {
+			cleanUp, wallet, err := createTestWallet()
+			if err != nil {
+				t.Fatalf("unable to create wallet: %v", err)
+			}
+
+			keyRing := NewWalletKeyRing(wallet)
+
+			return "dcrwallet", cleanUp, keyRing, nil
+		},
+	)
+
+}
+
+// TestDcrwalletSecretKeyRingImpl tests whether the WalletKeyRing
+// implementation conforms to the required interface spec.
+func TestDcrwalletSecretKeyRingImpl(t *testing.T) {
+	t.Parallel()
+
+	keychain.CheckSecretKeyRingImpl(t,
+		func() (string, func(), keychain.SecretKeyRing, error) {
+			cleanUp, wallet, err := createTestWallet()
+			if err != nil {
+				t.Fatalf("unable to create wallet: %v", err)
+			}
+
+			keyRing := NewWalletKeyRing(wallet)
+
+			return "dcrwallet", cleanUp, keyRing, nil
+		},
+	)
+
+}
+
+func init() {
+	// We'll clamp the max range scan to constrain the run time of the
+	// private key scan test.
+	keychain.MaxKeyRangeScan = 3
+}

--- a/lnwallet/dcrwallet/signer.go
+++ b/lnwallet/dcrwallet/signer.go
@@ -122,7 +122,7 @@ func (b *DcrWallet) SignOutputRaw(tx *wire.MsgTx,
 
 	// First attempt to fetch the private key which corresponds to the
 	// specified public key.
-	privKey, err := b.keyring.DerivePrivKey(signDesc.KeyDesc)
+	privKey, err := b.DerivePrivKey(signDesc.KeyDesc)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (b *DcrWallet) SignMessage(pubKey *secp256k1.PublicKey,
 
 	// First attempt to fetch the private key which corresponds to the
 	// specified public key.
-	privKey, err := b.keyring.DerivePrivKey(keyDesc)
+	privKey, err := b.DerivePrivKey(keyDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/lnwallet/dcrwallet/wallet.go
+++ b/lnwallet/dcrwallet/wallet.go
@@ -15,7 +15,6 @@ import (
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
 
-	"github.com/decred/dcrlnd/keychain"
 	"github.com/decred/dcrlnd/lnwallet"
 
 	walletloader "github.com/decred/dcrwallet/loader"
@@ -32,6 +31,12 @@ const (
 // backed by an active instance of dcrwallet. At the time of the writing of
 // this documentation, this implementation requires a full dcrd node to
 // operate.
+//
+// This struct implements the lnwallet.Signer, lnWallet.MessageSigner,
+// keychain.SecretKeyRing and keychain.KeyRing interfaces.
+//
+// Note that most of its functions might produce errors or panics until the
+// wallet has been fully synced.
 type DcrWallet struct {
 	// wallet is an active instance of dcrwallet.
 	wallet             *base.Wallet
@@ -49,7 +54,7 @@ type DcrWallet struct {
 
 	syncer WalletSyncer
 
-	keyring keychain.SecretKeyRing
+	*walletKeyRing
 }
 
 // A compile time check to ensure that DcrWallet implements the
@@ -106,7 +111,6 @@ func New(cfg Config) (*DcrWallet, error) {
 		syncer:    syncer,
 		netParams: cfg.NetParams,
 		utxoCache: make(map[wire.OutPoint]*wire.TxOut),
-		keyring:   NewWalletKeyRing(wallet),
 	}, nil
 }
 
@@ -694,5 +698,19 @@ func (b *DcrWallet) IsSynced() (bool, int64, error) {
 
 func (b *DcrWallet) onRPCSyncerSynced(synced bool) {
 	dcrwLog.Debug("RPC syncer notified wallet is synced")
+
+	// Now that the wallet is synced and address discovery has ended, we
+	// can create the keyring. We can only do this here (after sync)
+	// because address discovery might upgrade the underlying dcrwallet
+	// coin type.
+	var err error
+	b.walletKeyRing, err = newWalletKeyRing(b.wallet, b.cfg.DB)
+	if err != nil {
+		// Sign operations will fail, so signal the error and prevent
+		// the wallet from considering itself synced (to prevent usage)
+		dcrwLog.Errorf("Unable to create wallet key ring: %v", err)
+		return
+	}
+
 	atomic.StoreUint32(&b.atomicWalletSynced, 1)
 }

--- a/lnwallet/dcrwallet/wallet.go
+++ b/lnwallet/dcrwallet/wallet.go
@@ -106,7 +106,7 @@ func New(cfg Config) (*DcrWallet, error) {
 		syncer:    syncer,
 		netParams: cfg.NetParams,
 		utxoCache: make(map[wire.OutPoint]*wire.TxOut),
-		keyring:   keychain.NewWalletKeyRing(wallet),
+		keyring:   NewWalletKeyRing(wallet),
 	}, nil
 }
 

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -325,16 +325,10 @@ func loadTestCredits(miner *rpctest.Harness, w *lnwallet.LightningWallet,
 
 // createTestWallet creates a test LightningWallet will a total of 20DCR
 // available for funding channels.
-func createTestWallet(tempTestDir string, miningNode *rpctest.Harness,
+func createTestWallet(cdb *channeldb.DB, miningNode *rpctest.Harness,
 	netParams *chaincfg.Params, notifier chainntnfs.ChainNotifier,
 	wc lnwallet.WalletController, keyRing keychain.SecretKeyRing,
 	signer lnwallet.Signer, bio lnwallet.BlockChainIO) (*lnwallet.LightningWallet, error) {
-
-	dbDir := filepath.Join(tempTestDir, "cdb")
-	cdb, err := channeldb.Open(dbDir)
-	if err != nil {
-		return nil, err
-	}
 
 	cfg := lnwallet.Config{
 		Database:         cdb,
@@ -2491,6 +2485,20 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 	}
 	defer os.RemoveAll(tempTestDirBob)
 
+	aliceDBDir := filepath.Join(tempTestDirAlice, "cdb")
+	aliceCDB, err := channeldb.Open(aliceDBDir)
+	if err != nil {
+		t.Fatalf("unable to open alice cdb: %v", err)
+	}
+	defer aliceCDB.Close()
+
+	bobDBDir := filepath.Join(tempTestDirBob, "cdb")
+	bobCDB, err := channeldb.Open(bobDBDir)
+	if err != nil {
+		t.Fatalf("unable to open bob cdb: %v", err)
+	}
+	defer bobCDB.Close()
+
 	walletType := walletDriver.WalletType
 	switch walletType {
 	case "dcrwallet":
@@ -2532,15 +2540,14 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 			NetParams:    netParams,
 			Syncer:       aliceSyncer,
 			FeeEstimator: feeEstimator,
+			DB:           aliceCDB,
 		}
 		aliceWalletController, err = walletDriver.New(aliceWalletConfig)
 		if err != nil {
 			t.Fatalf("unable to create alice wallet: %v", err)
 		}
 		aliceSigner = aliceWalletController.(*dcrwallet.DcrWallet)
-		aliceKeyRing = dcrwallet.NewWalletKeyRing(
-			aliceWalletController.(*dcrwallet.DcrWallet).InternalWallet(),
-		)
+		aliceKeyRing = aliceWalletController.(*dcrwallet.DcrWallet)
 
 		bobSeed := sha256.New()
 		bobSeed.Write([]byte(backEnd))
@@ -2554,23 +2561,21 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 			NetParams:    netParams,
 			Syncer:       bobSyncer,
 			FeeEstimator: feeEstimator,
+			DB:           bobCDB,
 		}
 		bobWalletController, err = walletDriver.New(bobWalletConfig)
 		if err != nil {
 			t.Fatalf("unable to create bob wallet: %v", err)
 		}
 		bobSigner = bobWalletController.(*dcrwallet.DcrWallet)
-		bobKeyRing = dcrwallet.NewWalletKeyRing(
-			bobSigner.(*dcrwallet.DcrWallet).InternalWallet(),
-		)
-
+		bobKeyRing = bobWalletController.(*dcrwallet.DcrWallet)
 	default:
 		t.Fatalf("unknown wallet driver: %v", walletType)
 	}
 
 	// Funding via 20 outputs with 4DCR each.
 	alice, err := createTestWallet(
-		tempTestDirAlice, miningNode, netParams,
+		aliceCDB, miningNode, netParams,
 		chainNotifier, aliceWalletController, aliceKeyRing,
 		aliceSigner, aliceBio,
 	)
@@ -2580,7 +2585,7 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 	defer alice.Shutdown()
 
 	bob, err := createTestWallet(
-		tempTestDirBob, miningNode, netParams,
+		bobCDB, miningNode, netParams,
 		chainNotifier, bobWalletController, bobKeyRing,
 		bobSigner, bobBio,
 	)

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -2538,7 +2538,7 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 			t.Fatalf("unable to create alice wallet: %v", err)
 		}
 		aliceSigner = aliceWalletController.(*dcrwallet.DcrWallet)
-		aliceKeyRing = keychain.NewWalletKeyRing(
+		aliceKeyRing = dcrwallet.NewWalletKeyRing(
 			aliceWalletController.(*dcrwallet.DcrWallet).InternalWallet(),
 		)
 
@@ -2560,7 +2560,7 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 			t.Fatalf("unable to create bob wallet: %v", err)
 		}
 		bobSigner = bobWalletController.(*dcrwallet.DcrWallet)
-		bobKeyRing = keychain.NewWalletKeyRing(
+		bobKeyRing = dcrwallet.NewWalletKeyRing(
 			bobSigner.(*dcrwallet.DcrWallet).InternalWallet(),
 		)
 


### PR DESCRIPTION
The main goal for this changeset is to move the keyring implementation (which requires an active and unlocked backing dcrwallet) from the keychain package to the lnwallet/dcrwallet package.

This makes the keychain package cleaner, more generic and removes its dependency to dcrwallet packages in particular and allows future keyring implementations to _not_ be based on a local backing dcrwallet. 

It also binds the existing keyring implementation (WalletKeyRing) to the existing wallet driver, which makes sense since it entirely relies on the internal backing wallet.

Another change introduced is that the public keys generated for use within the LN processes are no longer generated inside the backing dcrwallet (via `NextAddress()` calls), but rather on the keyring itself, based on the root coin type extended private key provided by the wallet. This removes the need for the wallet to track the large(ish) amount of keys (with their associated addresses) used by LN scripts which should never appear on-chain and that the wallet doesn't even (currently) know how to deal with, given the fact that it doesn't understand how the LN scripts work. It also increases the uncoupling between dcrlnd and the backing dcrwallet, which might eventually allow dcrlnd to use remote (instead of embedded) wallets.

The individual commits should be sane enough to be reviewed individually if needed, performing the required changes in stages.