### PR TITLE
discovery: Disable DNS boostrapper

### DIFF
--- a/chainregistry.go
+++ b/chainregistry.go
@@ -393,19 +393,10 @@ var (
 	// TODO(roasbeef): extend and collapse these and chainparams.go into
 	// struct like chaincfg.Params
 	chainDNSSeeds = map[chainhash.Hash][][2]string{
-		decredMainnetGenesis: {
-			{
-				"dcr.nodes.lightning.directory",
-				"soa.nodes.lightning.directory",
-			},
-		},
-
-		decredTestnet3Genesis: {
-			{
-				"dcrtest.nodes.lightning.directory",
-				"soa.nodes.lightning.directory",
-			},
-		},
+		// TODO(decred): Add actual decred DNS seeder addresses once
+		// they're up.
+		decredMainnetGenesis:  nil,
+		decredTestnet3Genesis: nil,
 	}
 )
 

--- a/discovery/bootstrapper.go
+++ b/discovery/bootstrapper.go
@@ -23,6 +23,11 @@ import (
 	"github.com/decred/dcrlnd/tor"
 )
 
+// ErrNoAddressesFound is returned by the MultiSourceBootstrap to signal that
+// after attempting all available sub-bootstrappers, none returned a usable
+// address.
+var ErrNoAddressesFound = errors.New("no addresses found")
+
 func init() {
 	prand.Seed(time.Now().Unix())
 }
@@ -89,7 +94,7 @@ func MultiSourceBootstrap(ctx context.Context, ignore map[autopilot.NodeID]struc
 	}
 
 	if len(addrs) == 0 {
-		return nil, errors.New("no addresses found")
+		return nil, ErrNoAddressesFound
 	}
 
 	log.Infof("Obtained %v addrs to bootstrap network with", len(addrs))
@@ -378,6 +383,10 @@ func (d *DNSSeedBootstrapper) SampleNodeAddrs(ctx context.Context,
 	numAddrs uint32, ignore map[autopilot.NodeID]struct{}) ([]*lnwire.NetAddress, error) {
 
 	var netAddrs []*lnwire.NetAddress
+
+	if len(d.dnsSeeds) == 0 {
+		return nil, errors.New("empty dns seeder")
+	}
 
 	// We'll continue this loop until we reach our target address limit.
 	// Each SRV query to the seed will return 25 random nodes, so we can


### PR DESCRIPTION
This disables the dns bootstrapper on current dcrlnd networks since
the corresponding seeders aren't up yet.

It does so by clearing the hard coded DNS seeder addresses and adding a
special case that exits early if no addresses are returned by the
bootstrapping process.

It also fixes a logic error condition where bootstrapping wasn't
re-enabled after the backoff period after the initial bootstrapping
phase.
