### PR TITLE
lnwallet: Add InitialSyncChannel to WalletController

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -299,21 +299,10 @@ func lndMain() error {
 	ltndLog.Infof("Waiting for chain backend to finish sync, "+
 		"start_height=%v", bestHeight)
 
-	for {
-		if !signal.Alive() {
-			return nil
-		}
-
-		synced, _, err := activeChainControl.wallet.IsSynced()
-		if err != nil {
-			return err
-		}
-
-		if synced {
-			break
-		}
-
-		time.Sleep(time.Second * 1)
+	select {
+	case <-signal.ShutdownChannel():
+		return nil
+	case <-activeChainControl.wallet.InitialSyncChannel():
 	}
 
 	_, bestHeight, err = activeChainControl.chainIO.GetBestBlock()

--- a/lnwallet/dcrwallet/wallet.go
+++ b/lnwallet/dcrwallet/wallet.go
@@ -38,6 +38,10 @@ type DcrWallet struct {
 	loader             *walletloader.Loader
 	atomicWalletSynced uint32 // CAS (synced=1) when wallet syncing complete
 
+	// syncedChan is a channel that is closed once the wallet has initially
+	// synced to the network. It is protected by atomicWalletSynced.
+	syncedChan chan struct{}
+
 	cfg *Config
 
 	netParams *chaincfg.Params
@@ -100,13 +104,14 @@ func New(cfg Config) (*DcrWallet, error) {
 	}
 
 	return &DcrWallet{
-		cfg:       &cfg,
-		wallet:    wallet,
-		loader:    loader,
-		syncer:    syncer,
-		netParams: cfg.NetParams,
-		utxoCache: make(map[wire.OutPoint]*wire.TxOut),
-		keyring:   keychain.NewWalletKeyRing(wallet),
+		cfg:        &cfg,
+		wallet:     wallet,
+		loader:     loader,
+		syncer:     syncer,
+		syncedChan: make(chan struct{}),
+		netParams:  cfg.NetParams,
+		utxoCache:  make(map[wire.OutPoint]*wire.TxOut),
+		keyring:    keychain.NewWalletKeyRing(wallet),
 	}, nil
 }
 
@@ -692,7 +697,19 @@ func (b *DcrWallet) IsSynced() (bool, int64, error) {
 	return walletSynced, walletBestHeader.Timestamp.Unix(), nil
 }
 
+// InitialSyncChannel returns the channel used to signal that wallet init has
+// finished.
+//
+// This is a part of the WalletController interface.
+func (b *DcrWallet) InitialSyncChannel() <-chan struct{} {
+	return b.syncedChan
+}
+
 func (b *DcrWallet) onRPCSyncerSynced(synced bool) {
 	dcrwLog.Debug("RPC syncer notified wallet is synced")
-	atomic.StoreUint32(&b.atomicWalletSynced, 1)
+
+	// Signal that the wallet is synced by closing the channel.
+	if atomic.CompareAndSwapUint32(&b.atomicWalletSynced, 0, 1) {
+		close(b.syncedChan)
+	}
 }

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -219,6 +219,11 @@ type WalletController interface {
 	// known to the wallet, expressed in Unix epoch time
 	IsSynced() (bool, int64, error)
 
+	// InitialSyncChannel returns a channel that is closed once the wallet
+	// has performed its initial sync procedures, is caught up to the
+	// network and potentially ready for use.
+	InitialSyncChannel() <-chan struct{}
+
 	// Start initializes the wallet, making any necessary connections,
 	// starting up required goroutines etc.
 	Start() error

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -366,27 +366,6 @@ func createTestWallet(tempTestDir string, miningNode *rpctest.Harness,
 		return nil, err
 	}
 
-	// Wait for the initial wallet sync and rescan.
-	timeout := time.After(time.Second * 120)
-	var synced bool
-	for !synced {
-		// Do a short wait
-		select {
-		case <-timeout:
-			return nil, fmt.Errorf("timeout after 30 while performing initial sync")
-		case <-time.Tick(500 * time.Millisecond):
-			synced, _, err = wallet.IsSynced()
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	// Load our test wallet with 20 outputs each holding 4DCR.
-	if err := loadTestCredits(miningNode, wallet, vw.GenerateBlocks, 20, 4); err != nil {
-		return nil, err
-	}
-
 	return wallet, nil
 }
 
@@ -2585,6 +2564,31 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 		t.Fatalf("unable to create test ln wallet: %v", err)
 	}
 	defer bob.Shutdown()
+
+	// Wait for both wallets to be synced.
+	timeout := time.After(time.Second * 120)
+	aliceSync := aliceWalletController.InitialSyncChannel()
+	bobSync := bobWalletController.InitialSyncChannel()
+	for aliceSync != nil || bobSync != nil {
+		select {
+		case <-timeout:
+			t.Fatalf("timeout while waiting for wallets to sync")
+		case <-aliceSync:
+			t.Logf("Alice synced")
+			aliceSync = nil
+		case <-bobSync:
+			t.Logf("Bob synced")
+			bobSync = nil
+		}
+	}
+
+	// Load our test wallets with 20 outputs each holding 4DCR.
+	if err := loadTestCredits(miningNode, alice, votingWallet.GenerateBlocks, 20, 4); err != nil {
+		t.Logf("unable to send initial funds to alice: %v", err)
+	}
+	if err := loadTestCredits(miningNode, bob, votingWallet.GenerateBlocks, 20, 4); err != nil {
+		t.Logf("unable to send initial funds to bob: %v", err)
+	}
 
 	// Both wallets should now have 80DCR available for
 	// spending.

--- a/mock.go
+++ b/mock.go
@@ -275,6 +275,11 @@ func (*mockWalletController) SubscribeTransactions() (lnwallet.TransactionSubscr
 func (*mockWalletController) IsSynced() (bool, int64, error) {
 	return true, int64(0), nil
 }
+func (*mockWalletController) InitialSyncChannel() <-chan struct{} {
+	c := make(chan struct{})
+	close(c)
+	return c
+}
 func (*mockWalletController) Start() error {
 	return nil
 }


### PR DESCRIPTION
This adds the InitialSyncChannel function to the WalletController
interface, so that wallet drivers can signal that all initial sync
procedures have completed.

This is used as a replacement for the busy wait on IsSynced(), which is
less than ideal from a performance point of view and also allows faster
node startup during integration tests.

