### PR TITLE
make: Match lint target to travis rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ COVER = for dir in $(GOLISTCOVER); do \
 
 LINT = $(LINT_BIN) \
 	run \
+	--build-tags rpctest \
 	--disable-all \
 	--enable=gofmt \
 	--enable=vet \


### PR DESCRIPTION
Makes it so that `make lint` execute the exact same directives as travis will.