### PR TITLE
Use server.Started() to signal server subservices started

### DIFF
--- a/lntest/node.go
+++ b/lntest/node.go
@@ -447,15 +447,6 @@ func (hn *HarnessNode) initLightningClient(conn *grpc.ClientConn) error {
 	hn.wg.Add(1)
 	go hn.lightningNetworkWatcher()
 
-	// TODO: add some user-verifiable signal that the node is ready for
-	// standard operations (all services and goroutines started, etc).
-	// Without this wait here, sometimes test functions will attempt to
-	// perform some operation right after the node process has started but
-	// before some service goroutine has had enough time to perform its
-	// duties and will then fail in mysterious ways.
-	time.Sleep(time.Second * 3)
-	hn.AddToLog(fmt.Sprintf("+++++ HarnessNode %s considered started\n", hn.Name()))
-
 	return nil
 }
 

--- a/server.go
+++ b/server.go
@@ -933,7 +933,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 // Started returns true if the server has been started, and false otherwise.
 // NOTE: This function is safe for concurrent access.
 func (s *server) Started() bool {
-	return atomic.LoadInt32(&s.started) != 0
+	return atomic.LoadInt32(&s.started) > 1
 }
 
 // Start starts the main daemon server, all requested listeners, and any helper
@@ -1032,6 +1032,9 @@ func (s *server) Start() error {
 	// based on a channel's status.
 	s.wg.Add(1)
 	go s.watchChannelStatus()
+
+	// Register that all services have started.
+	atomic.StoreInt32(&s.started, 2)
 
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -1773,6 +1773,15 @@ func (s *server) establishPersistentConnections() error {
 			s.persistentPeersBackoff[pubStr] = cfg.MinBackoff
 		}
 
+		// We might have been contacted by this peer at this point, so
+		// check that and ignore if we already have a connection.
+		peer, err := s.findPeerByPubStr(pubStr)
+		if err == nil {
+			srvrLog.Debugf("Skipping already connected persistent "+
+				"peer %x@%s", pubStr, peer)
+			continue
+		}
+
 		for _, address := range nodeAddr.addresses {
 			// Create a wrapper address which couples the IP and
 			// the pubkey so the brontide authenticated connection


### PR DESCRIPTION
This makes it so the server.Started() function correctly reports the the server's sub-services have started and removes a now unnecessary wait in harness nodes.