### PR TITLE
Nodelay keyfam wallet

### DIFF
--- a/lnwallet/remotedcrwallet/keychain.go
+++ b/lnwallet/remotedcrwallet/keychain.go
@@ -3,18 +3,35 @@ package remotedcrwallet
 import (
 	"errors"
 
+	"github.com/decred/dcrd/dcrutil/v2"
 	"github.com/decred/dcrd/hdkeychain/v2"
 	"github.com/decred/dcrlnd/channeldb"
 	"github.com/decred/dcrlnd/keychain"
+	"github.com/decred/dcrlnd/lnwallet"
 )
+
+// onchainAddrSourcer is an interface for the required operations needed to
+// derive keys that also correspond to regular onchain wallet addresses.
+type onchainAddrSourcer interface {
+	// NewAddress must return the next usable onchain address for the
+	// wallet.
+	NewAddress(t lnwallet.AddressType, change bool) (dcrutil.Address, error)
+
+	// Bip44AddressInfo returns the respective account, branch and index
+	// for the given wallet address.
+	Bip44AddressInfo(addr dcrutil.Address) (uint32, uint32, uint32, error)
+}
 
 // remoteWalletKeyRing is an implementation of both the KeyRing and
 // SecretKeyRing interfaces backed by a root master HD key.
 type remoteWalletKeyRing struct {
 	*keychain.HDKeyRing
 
-	rootXPriv       *hdkeychain.ExtendedKey
-	multiSigKFXpriv *hdkeychain.ExtendedKey
+	onchainAddrs onchainAddrSourcer
+
+	rootXPriv          *hdkeychain.ExtendedKey
+	multiSigKFXpriv    *hdkeychain.ExtendedKey
+	paymentBaseKFXpriv *hdkeychain.ExtendedKey
 
 	// db is a pointer to a channeldb.DB instance that stores the indices
 	// of used keys of the keyring. This is used to track the next
@@ -30,7 +47,8 @@ var _ keychain.SecretKeyRing = (*remoteWalletKeyRing)(nil)
 // newRemoteWalletKeyRing creates a new implementation of the
 // keychain.SecretKeyRing interface backed by the given root extended private
 // key.
-func newRemoteWalletKeyRing(rootAccountXPriv *hdkeychain.ExtendedKey, db *channeldb.DB) (*remoteWalletKeyRing, error) {
+func newRemoteWalletKeyRing(rootAccountXPriv *hdkeychain.ExtendedKey,
+	db *channeldb.DB, onchainAddrs onchainAddrSourcer) (*remoteWalletKeyRing, error) {
 
 	if !rootAccountXPriv.IsPrivate() {
 		return nil, errors.New("Provided key is not an extended private key")
@@ -64,9 +82,27 @@ func newRemoteWalletKeyRing(rootAccountXPriv *hdkeychain.ExtendedKey, db *channe
 	}
 	masterPubs[keychain.KeyFamilyMultiSig] = multiSigXPub
 
+	// The masterpub for the payment base key family (i.e. addresses used
+	// for our non-encumbered output in remote commitments) is the internal
+	// branch for the root account xpriv provided. This allows the wallet
+	// to directly spend these funds when a breach or DLP scenario is
+	// triggered without requiring any other off-chain state.
+	paymentBaseXPriv, err := rootAccountXPriv.Child(0)
+	if err != nil {
+		return nil, err
+	}
+	paymentBaseXPub, err := paymentBaseXPriv.Neuter()
+	if err != nil {
+		return nil, err
+	}
+	masterPubs[keychain.KeyFamilyPaymentBase] = paymentBaseXPub
+
 	// Derive the master pubs for the other key families.
 	for i := uint32(0); i <= lastKeyFam; i++ {
-		if i == uint32(keychain.KeyFamilyMultiSig) {
+		switch keychain.KeyFamily(i) {
+		case keychain.KeyFamilyMultiSig:
+			continue
+		case keychain.KeyFamilyPaymentBase:
 			continue
 		}
 
@@ -86,9 +122,11 @@ func newRemoteWalletKeyRing(rootAccountXPriv *hdkeychain.ExtendedKey, db *channe
 	}
 
 	wkr := &remoteWalletKeyRing{
-		rootXPriv:       rootXPriv,
-		multiSigKFXpriv: multiSigXPriv,
-		db:              db,
+		rootXPriv:          rootXPriv,
+		multiSigKFXpriv:    multiSigXPriv,
+		paymentBaseKFXpriv: paymentBaseXPriv,
+		db:                 db,
+		onchainAddrs:       onchainAddrs,
 	}
 	wkr.HDKeyRing = keychain.NewHDKeyRing(masterPubs, wkr.fetchMasterPriv,
 		wkr.nextIndex)
@@ -96,16 +134,51 @@ func newRemoteWalletKeyRing(rootAccountXPriv *hdkeychain.ExtendedKey, db *channe
 }
 
 func (kr *remoteWalletKeyRing) nextIndex(keyFam keychain.KeyFamily) (uint32, error) {
+	switch keyFam {
+	case keychain.KeyFamilyMultiSig,
+		keychain.KeyFamilyPaymentBase:
+
+		// For these key families, instead of using the channel
+		// database to track indices we request the next available
+		// address from the wallet (with the wrap gap policy) and
+		// decode its index.
+		//
+		// The net result is that the wallet should always be able to
+		// find these addresses and their respective keys during
+		// address discovery instead of requiring input from the
+		// lightning wallet.
+		branchInternal := keyFam == keychain.KeyFamilyPaymentBase
+		addr, err := kr.onchainAddrs.NewAddress(
+			lnwallet.PubKeyHash, branchInternal,
+		)
+		if err != nil {
+			return 0, err
+		}
+
+		_, _, addrIndex, err := kr.onchainAddrs.Bip44AddressInfo(addr)
+		if err != nil {
+			return 0, err
+		}
+		return addrIndex, nil
+
+	}
+
 	return kr.db.NextKeyFamilyIndex(uint32(keyFam))
 }
 
 func (kr *remoteWalletKeyRing) fetchMasterPriv(keyFam keychain.KeyFamily) (*hdkeychain.ExtendedKey,
 	error) {
 
-	if keyFam == keychain.KeyFamilyMultiSig {
+	// The master priv of the special key families that correspond to
+	// regular on-chain branches are stored separately.
+	switch keyFam {
+	case keychain.KeyFamilyMultiSig:
 		return kr.multiSigKFXpriv, nil
+	case keychain.KeyFamilyPaymentBase:
+		return kr.paymentBaseKFXpriv, nil
 	}
 
+	// For the other keyfamilies, derive from the alternative root branch.
 	idx := uint32(hdkeychain.HardenedKeyStart + keyFam)
 	famKey, err := kr.rootXPriv.Child(idx)
 	if err != nil {

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -22,8 +22,8 @@ import (
 const (
 	// DefaultMaxFeeRate is the default maximum fee rate allowed within the
 	// UtxoSweeper. The current value is equivalent to a fee rate of
-	// 100.000 atoms/KByte.
-	DefaultMaxFeeRate lnwallet.AtomPerKByte = 1e5
+	// 0.00100000 DCR/KByte.
+	DefaultMaxFeeRate lnwallet.AtomPerKByte = 1e6
 
 	// DefaultFeeRateBucketSize is the default size of fee rate buckets
 	// we'll use when clustering inputs into buckets with similar fee rates


### PR DESCRIPTION
This switches the remote dcrwallet driver to use the internal branch of
the ln account to derive keys for the payment base key family.

This, coupled with the tweakless mode for remote payment addresses 
recently introduced means the wallet is able to redeem funds after execution of 
the DLP protocol without requiring extra data.

This also changes the key derivation to call the wallet's own
NextAddress function, such that multisig and payment base keys are
derived directly on it and respect the standard gap limit policy so that
onchain fund recovery is more consistent.