### PR TITLE
Add Chainscan package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ lntest/itest/.backendlogs
 lntest/itest/.minerlogs
 lnwallet/output*.log
 lnwallet/.miner-logs*
+chainscan/csdrivers/.*
+chainscan/csdrivers/*.log
 
 cmd/cmd
 *.key

--- a/chainntnfs/dcrdnotify/dcrd.go
+++ b/chainntnfs/dcrdnotify/dcrd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/decred/dcrd/txscript/v3"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrlnd/chainntnfs"
+	"github.com/decred/dcrlnd/chainscan"
 	"github.com/decred/dcrlnd/queue"
 )
 
@@ -850,7 +851,7 @@ func txSpendsSpendRequest(tx *wire.MsgTx, spendRequest *chainntnfs.SpendRequest,
 	for i, in := range tx.TxIn {
 		// Ignore the errors here, due to them definitely not being a
 		// match.
-		pkScript, _ := chainntnfs.ComputePkScript(
+		pkScript, _ := chainscan.ComputePkScript(
 			spendRequest.PkScript.ScriptVersion(), in.SignatureScript,
 			addrParams,
 		)

--- a/chainntnfs/dcrdnotify/dcrd.go
+++ b/chainntnfs/dcrdnotify/dcrd.go
@@ -853,7 +853,6 @@ func txSpendsSpendRequest(tx *wire.MsgTx, spendRequest *chainntnfs.SpendRequest,
 		// match.
 		pkScript, _ := chainscan.ComputePkScript(
 			spendRequest.PkScript.ScriptVersion(), in.SignatureScript,
-			addrParams,
 		)
 		if spendRequest.PkScript.Equal(&pkScript) {
 			return i

--- a/chainntnfs/dcrdnotify/dcrd_test.go
+++ b/chainntnfs/dcrdnotify/dcrd_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/decred/dcrd/txscript/v3"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrlnd/chainntnfs"
+	"github.com/decred/dcrlnd/chainscan"
 	"github.com/decred/dcrlnd/channeldb"
 	"github.com/decred/dcrlnd/compat"
 )
@@ -308,7 +309,7 @@ func TestInneficientRescan(t *testing.T) {
 
 	// Store some helper constants.
 	endHeight := minedHeight + 20
-	pkScript, err := chainntnfs.ParsePkScript(txout.Version, txout.PkScript)
+	pkScript, err := chainscan.ParsePkScript(txout.Version, txout.PkScript)
 	if err != nil {
 		t.Fatalf("unable to parse pkscript: %v", err)
 	}

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -1414,7 +1414,7 @@ func (n *TxNotifier) filterTx(tx *dcrutil.Tx, blockHash *chainhash.Hash,
 			// requests.
 			prevOut := txIn.PreviousOutPoint
 			pkScript, err := chainscan.ComputePkScript(
-				0, txIn.SignatureScript, n.chainParams,
+				0, txIn.SignatureScript,
 			)
 			if err != nil {
 				continue

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -11,6 +11,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/v2"
 	"github.com/decred/dcrd/dcrutil/v3"
 	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrlnd/chainscan"
 	"github.com/decred/dcrlnd/channeldb"
 )
 
@@ -155,7 +156,7 @@ type ConfRequest struct {
 
 	// PkScript is the public key script of an outpoint created in this
 	// transaction.
-	PkScript PkScript
+	PkScript chainscan.PkScript
 }
 
 // NewConfRequest creates a request for a confirmation notification of either a
@@ -164,7 +165,7 @@ type ConfRequest struct {
 func NewConfRequest(txid *chainhash.Hash, pkScript []byte) (ConfRequest, error) {
 	var r ConfRequest
 	scriptVersion := uint16(0)
-	outputScript, err := ParsePkScript(scriptVersion, pkScript)
+	outputScript, err := chainscan.ParsePkScript(scriptVersion, pkScript)
 	if err != nil {
 		return r, err
 	}
@@ -301,7 +302,7 @@ type SpendRequest struct {
 
 	// PkScript is the script of the outpoint. If a zero outpoint is set,
 	// then this can be an arbitrary script.
-	PkScript PkScript
+	PkScript chainscan.PkScript
 }
 
 // NewSpendRequest creates a request for a spend notification of either an
@@ -310,7 +311,7 @@ type SpendRequest struct {
 func NewSpendRequest(op *wire.OutPoint, pkScript []byte) (SpendRequest, error) {
 	var r SpendRequest
 	scriptVersion := uint16(0)
-	outputScript, err := ParsePkScript(scriptVersion, pkScript)
+	outputScript, err := chainscan.ParsePkScript(scriptVersion, pkScript)
 	if err != nil {
 		return r, err
 	}
@@ -1412,7 +1413,7 @@ func (n *TxNotifier) filterTx(tx *dcrutil.Tx, blockHash *chainhash.Hash,
 			// to determine if the inputs spends any registered
 			// requests.
 			prevOut := txIn.PreviousOutPoint
-			pkScript, err := ComputePkScript(
+			pkScript, err := chainscan.ComputePkScript(
 				0, txIn.SignatureScript, n.chainParams,
 			)
 			if err != nil {
@@ -1461,7 +1462,7 @@ func (n *TxNotifier) filterTx(tx *dcrutil.Tx, blockHash *chainhash.Hash,
 			// We'll parse the script of the output to determine if
 			// we have any registered requests for it or the
 			// transaction itself.
-			pkScript, err := ParsePkScript(0, txOut.PkScript)
+			pkScript, err := chainscan.ParsePkScript(0, txOut.PkScript)
 			if err != nil {
 				continue
 			}

--- a/chainscan/csdrivers/dcrwdriver.go
+++ b/chainscan/csdrivers/dcrwdriver.go
@@ -1,0 +1,228 @@
+package csdrivers
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"decred.org/dcrwallet/errors"
+	"decred.org/dcrwallet/wallet"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/gcs/v2"
+	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrlnd/chainscan"
+)
+
+type cfilter struct {
+	height int32
+	hash   chainhash.Hash
+	key    [16]byte
+	filter *gcs.FilterV2
+}
+
+type eventReader struct {
+	ctx context.Context
+	c   chan chainscan.ChainEvent
+}
+
+// DcrwalletCSDriver...
+//
+// NOTE: Using an individual driver instance for more than either a single
+// historical or tip watcher scanner leads to undefined behavior.
+type DcrwalletCSDriver struct {
+	w *wallet.Wallet
+
+	mtx      sync.Mutex
+	ereaders []*eventReader
+
+	// The following are members that define a cfilter cache which is
+	// useful to reduce db contention by reading cfilters in batches.
+	cache            []cfilter
+	cacheStartHeight int32
+}
+
+// Type assertions to ensure the driver fulfills the correct interfaces.
+var _ chainscan.HistoricalChainSource = (*DcrwalletCSDriver)(nil)
+var _ chainscan.TipChainSource = (*DcrwalletCSDriver)(nil)
+
+// Hint for the capacity of the cache size. Value is arbitrary at this point.
+var cacheCapHint = 200
+
+func NewDcrwalletCSDriver(w *wallet.Wallet) *DcrwalletCSDriver {
+	return &DcrwalletCSDriver{
+		w:     w,
+		cache: make([]cfilter, 0, cacheCapHint),
+	}
+}
+
+func (d *DcrwalletCSDriver) signalEventReaders(e chainscan.ChainEvent) {
+	d.mtx.Lock()
+	readers := d.ereaders
+	d.mtx.Unlock()
+
+	for _, er := range readers {
+		select {
+		case <-er.ctx.Done():
+		case er.c <- e:
+		}
+	}
+}
+
+// Run runs the driver. It should be executed on a separate goroutine. This is
+// only needed if the NextTip() function is going to be used such as when using
+// this driver as a source for a TipWatcher scanner.
+func (d *DcrwalletCSDriver) Run(ctx context.Context) error {
+	log.Debugf("Running chainscan driver with embedded dcrwallet")
+	client := d.w.NtfnServer.TransactionNotifications()
+	defer client.Done()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ntfn := <-client.C:
+			for _, b := range ntfn.DetachedBlocks {
+				e := chainscan.BlockDisconnectedEvent{
+					Hash:     b.BlockHash(),
+					Height:   int32(b.Height),
+					PrevHash: b.PrevBlock,
+				}
+
+				d.signalEventReaders(e)
+			}
+
+			for _, b := range ntfn.AttachedBlocks {
+				if b.Header == nil {
+					// Shouldn't happen, but play it safe.
+					continue
+				}
+
+				hash := b.Header.BlockHash()
+				key, filter, err := d.w.CFilterV2(ctx, &hash)
+				if err != nil {
+					log.Errorf("Error obtaining cfilter from wallet: %v", err)
+					return err
+				}
+
+				e := chainscan.BlockConnectedEvent{
+					PrevHash: b.Header.PrevBlock,
+					Hash:     hash,
+					Height:   int32(b.Header.Height),
+					CFKey:    key,
+					Filter:   filter,
+				}
+
+				d.signalEventReaders(e)
+			}
+		}
+	}
+
+}
+
+func (d *DcrwalletCSDriver) ChainEvents(ctx context.Context) <-chan chainscan.ChainEvent {
+	er := &eventReader{
+		ctx: ctx,
+		c:   make(chan chainscan.ChainEvent),
+	}
+	d.mtx.Lock()
+	d.ereaders = append(d.ereaders, er)
+	d.mtx.Unlock()
+
+	return er.c
+}
+
+// GetBlock returns the given block for the given blockhash. Note that for
+// wallets running in SPV mode this blocks until the wallet is connected to a
+// peer and it correctly returns a full block.
+func (d *DcrwalletCSDriver) GetBlock(ctx context.Context, bh *chainhash.Hash) (*wire.MsgBlock, error) {
+getblock:
+	for {
+		// Keep trying to get the network backend until the context is
+		// canceled.
+		n, err := d.w.NetworkBackend()
+		if errors.Is(err, errors.NoPeers) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Second):
+				continue getblock
+			}
+		}
+
+		blocks, err := n.Blocks(ctx, []*chainhash.Hash{bh})
+		if len(blocks) > 0 && err == nil {
+			return blocks[0], nil
+		}
+
+		// The syncer might have failed due to any number of reasons,
+		// but it's likely it will come back online shortly. So wait
+		// until we can try again.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func (d *DcrwalletCSDriver) CurrentTip(ctx context.Context) (*chainhash.Hash, int32, error) {
+	bh, h := d.w.MainChainTip(ctx)
+	return &bh, h, nil
+}
+
+// GetCFilter is part of the chainscan.HistoricalChainSource interface.
+//
+// NOTE: The returned chainhash pointer is not safe for storage as it belongs
+// to a cache entry. This is fine for use on a chainscan.Historical scanner
+// since it never stores or leaks the pointer itself.
+func (d *DcrwalletCSDriver) GetCFilter(ctx context.Context, height int32) (*chainhash.Hash, [16]byte, *gcs.FilterV2, error) {
+	// Fast track when data is in memory.
+	if height >= d.cacheStartHeight && height < d.cacheStartHeight+int32(len(d.cache)) {
+		i := int(height - d.cacheStartHeight)
+		c := &d.cache[i]
+		return &c.hash, c.key, c.filter, nil
+	}
+
+	// Read a bunch of cfilters in one go since it's likely we'll be
+	// queried for the next few.
+	start := wallet.NewBlockIdentifierFromHeight(height)
+	i := 0
+	d.cache = d.cache[:cap(d.cache)]
+	rangeFn := func(bh chainhash.Hash, key [16]byte, filter *gcs.FilterV2) (bool, error) {
+		d.cache[i] = cfilter{
+			hash:   bh,
+			height: height + int32(i),
+			key:    key,
+			filter: filter,
+		}
+
+		// Stop if the cache has been filled.
+		i++
+		return i >= cap(d.cache), nil
+	}
+	err := d.w.RangeCFiltersV2(ctx, start, nil, rangeFn)
+	if err != nil {
+		return nil, [16]byte{}, nil, err
+	}
+
+	// If we didn't read any filters from the db, it means we were
+	// requested a filter past the current mainchain tip. Inform the
+	// appropriate error in this case.
+	if i == 0 {
+		return nil, [16]byte{}, nil, chainscan.ErrBlockAfterTip{Height: height}
+	}
+
+	// Clear out unused entries so we don't keep a reference to the filters
+	// forever.
+	for j := i; j < cap(d.cache); j++ {
+		d.cache[j].filter = nil
+	}
+
+	// Keep track of correct cache start and size.
+	d.cache = d.cache[:i]
+	d.cacheStartHeight = height
+
+	// The desired filter is the first one.
+	c := &d.cache[0]
+	return &c.hash, c.key, c.filter, nil
+}

--- a/chainscan/csdrivers/dcrwdriver_test.go
+++ b/chainscan/csdrivers/dcrwdriver_test.go
@@ -1,0 +1,622 @@
+package csdrivers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"decred.org/dcrwallet/rpc/walletrpc"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/chaincfg/v3"
+	"github.com/decred/dcrd/gcs/v2"
+	"github.com/decred/dcrd/rpctest"
+	"github.com/decred/dcrlnd/chainscan"
+	"github.com/decred/dcrlnd/internal/testutils"
+	"github.com/decred/dcrlnd/lntest/wait"
+)
+
+var (
+	testHDSeed = chainhash.Hash{
+		0xb7, 0x94, 0x38, 0x5f, 0x2d, 0x1e, 0xf7, 0xab,
+		0x4d, 0x92, 0x73, 0xd1, 0x90, 0x63, 0x81, 0xb4,
+		0x4f, 0x2f, 0x6f, 0x25, 0x98, 0xa3, 0xef, 0xb9,
+		0x69, 0x49, 0x18, 0x83, 0x31, 0x98, 0x47, 0x53,
+	}
+
+	defaultTimeout = 5 * time.Second
+)
+
+type runnable interface {
+	Run(context.Context) error
+}
+
+type testHarness struct {
+	testutils.TB
+
+	d     interface{} // driver
+	miner *rpctest.Harness
+	vw    *rpctest.VotingWallet
+}
+
+func (t *testHarness) generate(nb uint32) []*chainhash.Hash {
+	t.Helper()
+
+	bls, err := t.vw.GenerateBlocks(context.Background(), nb)
+	if err != nil {
+		t.Fatalf("unable to generate %d blocks: %v", nb, err)
+	}
+	return bls
+}
+
+// assertMinerBlockHeightDelta ensures that tempMiner is 'delta' blocks ahead
+// of miner.
+func assertMinerBlockHeightDelta(t *testHarness,
+	miner, tempMiner *rpctest.Harness, delta int64) {
+
+	ctxb := context.Background()
+
+	// Ensure the chain lengths are what we expect.
+	var predErr error
+	err := wait.Predicate(func() bool {
+		_, tempMinerHeight, err := tempMiner.Node.GetBestBlock(ctxb)
+		if err != nil {
+			predErr = fmt.Errorf("unable to get current "+
+				"blockheight %v", err)
+			return false
+		}
+
+		_, minerHeight, err := miner.Node.GetBestBlock(ctxb)
+		if err != nil {
+			predErr = fmt.Errorf("unable to get current "+
+				"blockheight %v", err)
+			return false
+		}
+
+		if tempMinerHeight != minerHeight+delta {
+			predErr = fmt.Errorf("expected new miner(%d) to be %d "+
+				"blocks ahead of original miner(%d)",
+				tempMinerHeight, delta, minerHeight)
+			return false
+		}
+		return true
+	}, time.Second*15)
+	if err != nil {
+		t.Fatalf(predErr.Error())
+	}
+}
+
+func assertMatchesMinerCF(t *testHarness, bh *chainhash.Hash, key [16]byte, filter *gcs.FilterV2) {
+	t.Helper()
+	ctxb := context.Background()
+
+	resp, err := t.miner.Node.GetCFilterV2(ctxb, bh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(resp.Filter.Bytes(), filter.Bytes()) {
+		t.Fatal("filter bytes do not match")
+	}
+	mbl, err := t.miner.Node.GetBlock(ctxb, bh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(mbl.Header.MerkleRoot[:16], key[:]) {
+		t.Fatal("key does not match")
+	}
+}
+
+func testCurrentTip(t *testHarness) {
+	d := t.d.(chainscan.ChainSource)
+
+	// Generate 5 blocks. The tip should match in every one.
+	for i := 0; i < 5; i++ {
+		err := wait.NoError(func() error {
+			ctxt, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+			defer cancel()
+			bh, h, err := d.CurrentTip(ctxt)
+			if err != nil {
+				return fmt.Errorf("unable to get current tip: %v", err)
+			}
+
+			// Compare to current miner tip.
+			hash, height, err := t.miner.Node.GetBestBlock(ctxt)
+			if err != nil {
+				return fmt.Errorf("unable to get best block: %v", err)
+			}
+			if int32(height) != h {
+				return fmt.Errorf("unexpected tip height. want=%d got=%d", height, h)
+			}
+			if *bh != *hash {
+				return fmt.Errorf("unexpected tip hash. want=%s got=%s", hash, bh)
+			}
+
+			return nil
+		}, defaultTimeout)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.generate(1)
+	}
+}
+
+func testGetCFilters(t *testHarness) {
+	d := t.d.(chainscan.HistoricalChainSource)
+
+	// Fetch a bunch of cfilters and compare it to the miner returned ones.
+	_, tipHeight, err := t.miner.Node.GetBestBlock(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for height := tipHeight - 10; height <= tipHeight; height++ {
+		ctxt, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		defer cancel()
+		bh, key, filter, err := d.GetCFilter(ctxt, int32(height))
+		if err != nil {
+			t.Fatalf("unable to get cfilter: %v", err)
+		}
+
+		// Compare to the miner.
+		mbh, err := t.miner.Node.GetBlockHash(context.Background(), height)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if *mbh != *bh {
+			t.Fatalf("unexpected block hash at height %d. want=%s got=%s",
+				height, mbh, bh)
+		}
+		assertMatchesMinerCF(t, bh, key, filter)
+	}
+
+	// Requesting a cfilter for a block past tip should return
+	// ErrBlockAfterTip.
+	ctxt, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	_, _, _, err = d.GetCFilter(ctxt, int32(tipHeight+1))
+	if !errors.Is(err, chainscan.ErrBlockAfterTip{}) {
+		t.Fatalf("unexpected error at tipHeight+1. want=%v got=%v",
+			chainscan.ErrBlockAfterTip{}, err)
+	}
+
+	// Requesting a cfilter for tip again shouldn't error.
+	ctxt, cancel = context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	_, _, _, err = d.GetCFilter(ctxt, int32(tipHeight))
+	if err != nil {
+		t.Fatalf("unexpected error at tipHeight. want=%v got=%v",
+			nil, err)
+	}
+}
+
+func testGetBlock(t *testHarness) {
+	d := t.d.(chainscan.ChainSource)
+
+	ctxb := context.Background()
+	_, tipHeight, err := t.miner.Node.GetBestBlock(ctxb)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fetch a bunch of blocks near tipHeight and ensure they match the
+	// ones from the miner.
+	for height := tipHeight - 5; height <= tipHeight; height++ {
+		mbh, err := t.miner.Node.GetBlockHash(ctxb, height)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mbl, err := t.miner.Node.GetBlock(ctxb, mbh)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctxt, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		defer cancel()
+		bl, err := d.GetBlock(ctxt, mbh)
+		if err != nil {
+			t.Fatalf("unable to get block: %v", err)
+		}
+
+		blBytes, err := bl.Bytes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		mblBytes, err := mbl.Bytes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(blBytes, mblBytes) {
+			t.Fatalf("bytes from miner block do not equal bytes from driver block")
+		}
+	}
+}
+
+func testChainEvents(t *testHarness) {
+	d := t.d.(chainscan.TipChainSource)
+	if r, isRunnable := t.d.(runnable); isRunnable {
+		runCtx, cancelRun := context.WithCancel(context.Background())
+		go r.Run(runCtx)
+		defer cancelRun()
+	}
+
+	_, tipHeight, err := t.miner.Node.GetBestBlock(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		bh     *chainhash.Hash
+		height int32
+		key    [16]byte
+		filter *gcs.FilterV2
+	)
+
+	eventsCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events := d.ChainEvents(eventsCtx)
+
+	// Repeat the test 5 times.
+	for i := int32(0); i < 5; i++ {
+		mbh := t.generate(1)[0]
+		select {
+		case ce := <-events:
+			e := ce.(chainscan.BlockConnectedEvent)
+			bh, height = e.BlockHash(), e.BlockHeight()
+			key, filter = e.CFKey, e.Filter
+		case <-time.After(defaultTimeout):
+			t.Fatalf("timeout waiting for block %d", i)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if *bh != *mbh {
+			t.Fatalf("unexpected block hash. want=%s got=%s",
+				mbh, bh)
+		}
+		if height != int32(tipHeight)+i+1 {
+			t.Fatalf("unexpected height. want=%d got=%d",
+				int32(tipHeight)+i+1, height)
+		}
+
+		assertMatchesMinerCF(t, bh, key, filter)
+	}
+}
+
+// tests that using nextTip() when a reorg happens makes the driver get all new
+// (reorged in) blocks.
+func testChainEventsWithReorg(t *testHarness) {
+	d := t.d.(chainscan.TipChainSource)
+	if r, isRunnable := t.d.(runnable); isRunnable {
+		runCtx, cancelRun := context.WithCancel(context.Background())
+		go r.Run(runCtx)
+		defer cancelRun()
+	}
+
+	_, tipHeight, err := t.miner.Node.GetBestBlock(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a second miner.
+	netParams := chaincfg.SimNetParams()
+	tempMinerDir := ".dcrd-alt-miner"
+	tempMinerArgs := []string{"--debuglevel=debug", "--logdir=" + tempMinerDir}
+	tempMiner, err := rpctest.New(t.TB.(*testing.T), netParams, nil, tempMinerArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tempMiner.SetUp(false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempMiner.TearDown()
+
+	// Connect the temp miner with the orignal test miner and let them sync
+	// up.
+	if err := rpctest.ConnectNode(t.miner, tempMiner); err != nil {
+		t.Fatalf("unable to connect harnesses: %v", err)
+	}
+	nodeSlice := []*rpctest.Harness{t.miner, tempMiner}
+	if err := rpctest.JoinNodes(nodeSlice, rpctest.Blocks); err != nil {
+		t.Fatalf("unable to join node on blocks: %v", err)
+	}
+
+	// The two miners should be on the same blockheight.
+	assertMinerBlockHeightDelta(t, t.miner, tempMiner, 0)
+
+	// Disconnect both nodes.
+	err = rpctest.RemoveNode(context.Background(), t.miner, tempMiner)
+	if err != nil {
+		t.Fatalf("unable to remove node: %v", err)
+	}
+
+	// Create the chain events channel.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events := d.ChainEvents(ctx)
+
+	// Mine 3 blocks in the original miner and 6 in the temp miner.
+	t.generate(3)
+	_, err = testutils.AdjustedSimnetMiner(tempMiner.Node, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The two miners should be on different blockheights.
+	assertMinerBlockHeightDelta(t, t.miner, tempMiner, 3)
+
+	var (
+		bh     *chainhash.Hash
+		height int32
+		key    [16]byte
+		filter *gcs.FilterV2
+	)
+
+	// We should get 3 new tips when calling NextTip()
+	for i := int32(0); i < 3; i++ {
+		select {
+		case ce := <-events:
+			e := ce.(chainscan.BlockConnectedEvent)
+			bh, height = e.BlockHash(), e.BlockHeight()
+			key, filter = e.CFKey, e.Filter
+		case <-time.After(defaultTimeout):
+			t.Fatalf("timeout waiting for block %d", i)
+		}
+
+		if height != int32(tipHeight)+i+1 {
+			t.Fatalf("unexpected height. want=%d got=%d",
+				int32(tipHeight)+i+1, height)
+		}
+
+		assertMatchesMinerCF(t, bh, key, filter)
+	}
+
+	// Re-connect the miners. This should cause 6 news blocks to be
+	// connected (including ones for heights the we already just checked
+	// were connected).
+	if err := rpctest.ConnectNode(t.miner, tempMiner); err != nil {
+		t.Fatalf("unable to connect harnesses: %v", err)
+	}
+	if err := rpctest.JoinNodes(nodeSlice, rpctest.Blocks); err != nil {
+		t.Fatalf("unable to join node on blocks: %v", err)
+	}
+	assertMinerBlockHeightDelta(t, t.miner, tempMiner, 0)
+
+	// We should get 3 BlockDisconnected events from the old chain.
+	for i := int32(0); i < 3; i++ {
+		select {
+		case ce := <-events:
+			e := ce.(chainscan.BlockDisconnectedEvent)
+			_, height = e.BlockHash(), e.BlockHeight()
+			wantHeight := int32(tipHeight) + 3 - i
+			if height != wantHeight {
+				t.Fatalf("unexpected BlockDisconnectedEvent "+
+					"height. want=%d got=%d", wantHeight,
+					height)
+			}
+		case <-time.After(defaultTimeout):
+			t.Fatalf("timeout waiting for block disconnect %d", i)
+		}
+	}
+
+	// We should get 6 new tips when calling NextTip()
+	for i := int32(0); i < 6; i++ {
+		select {
+		case ce := <-events:
+			e := ce.(chainscan.BlockConnectedEvent)
+			bh, height = e.BlockHash(), e.BlockHeight()
+			key, filter = e.CFKey, e.Filter
+		case <-time.After(defaultTimeout):
+			t.Fatalf("timeout waiting for block %d", i)
+		}
+
+		// This is the important bit of this test. We've never reset
+		// tipHeight, therefore we should obverve again
+		// tipHeight+1..tipHeight+1+3.
+		if height != int32(tipHeight)+i+1 {
+			t.Fatalf("unexpected height. want=%d got=%d",
+				int32(tipHeight)+i+1, height)
+		}
+
+		assertMatchesMinerCF(t, bh, key, filter)
+	}
+}
+
+func setupTestChain(t testutils.TB, testName string) (*rpctest.Harness, *rpctest.VotingWallet, func()) {
+	tearDown := func() {}
+	defer func() {
+		if t.Failed() {
+			tearDown()
+		}
+	}()
+
+	netParams := chaincfg.SimNetParams()
+	minerLogDir := fmt.Sprintf(".dcrd-%s", testName)
+	minerArgs := []string{"--debuglevel=debug", "--logdir=" + minerLogDir}
+	miner, err := rpctest.New(t.(*testing.T), netParams, nil, minerArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = miner.SetUp(false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tearDown = func() {
+		miner.TearDown()
+	}
+
+	_, err = miner.Node.Generate(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = testutils.AdjustedSimnetMiner(miner.Node, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup a voting wallet for when the chain passes SVH.
+	vw, err := rpctest.NewVotingWallet(context.Background(), miner)
+	if err != nil {
+		t.Fatalf("unable to create voting wallet: %v", err)
+	}
+	vw.SetErrorReporting(func(err error) {
+		t.Logf("Voting wallet error: %v", err)
+	})
+	vw.SetMiner(func(ctx context.Context, nb uint32) ([]*chainhash.Hash, error) {
+		return testutils.AdjustedSimnetMiner(miner.Node, nb)
+	})
+	if err = vw.Start(); err != nil {
+		t.Fatalf("unable to start voting wallet: %v", err)
+	}
+	tearDown = func() {
+		vw.Stop()
+		miner.TearDown()
+	}
+
+	return miner, vw, tearDown
+}
+
+type testCase struct {
+	name string
+	f    func(*testHarness)
+}
+
+var testCases = []testCase{
+	// The reorg test needs to be the first one to ensure voting
+	// doesn't need to be taken into account.
+	{
+		name: "ChainEvents with reorg",
+		f:    testChainEventsWithReorg,
+	},
+	{
+		name: "CurrentTip",
+		f:    testCurrentTip,
+	},
+	{
+		name: "GetCFilters",
+		f:    testGetCFilters,
+	},
+	{
+		name: "GetBlock",
+		f:    testGetBlock,
+	},
+	{
+		name: "ChainEvents",
+		f:    testChainEvents,
+	},
+}
+
+func TestDcrwalletCSDriver(t *testing.T) {
+	miner, vw, tearDownMiner := setupTestChain(t, "dcwallet-csd")
+	defer tearDownMiner()
+
+	rpcConfig := miner.RPCConfig()
+	w, tearDownWallet := testutils.NewSyncingTestWallet(t, &rpcConfig)
+	defer tearDownWallet()
+
+	for _, tc := range testCases {
+		tc := tc
+		succ := t.Run(tc.name, func(t *testing.T) {
+			d := NewDcrwalletCSDriver(w)
+
+			// Lower the cache size so we're sure to trigger cases
+			// where the cache is both used and filled.
+			d.cache = make([]cfilter, 3)
+
+			th := &testHarness{
+				d:     d,
+				TB:    t,
+				miner: miner,
+				vw:    vw,
+			}
+			tc.f(th)
+		})
+		if !succ {
+			break
+		}
+	}
+}
+
+func TestRemoteDcrwalletCSDriver(t *testing.T) {
+	miner, vw, tearDownMiner := setupTestChain(t, "remotewallet-csd")
+	defer tearDownMiner()
+
+	rpcConfig := miner.RPCConfig()
+	conn, tearDownWallet := testutils.NewTestRemoteDcrwallet(t, &rpcConfig)
+	wsvc := walletrpc.NewWalletServiceClient(conn)
+	nsvc := walletrpc.NewNetworkServiceClient(conn)
+	defer tearDownWallet()
+
+	for _, tc := range testCases {
+		tc := tc
+		succ := t.Run(tc.name, func(t *testing.T) {
+			d := NewRemoteWalletCSDriver(wsvc, nsvc)
+
+			// Lower the cache size so we're sure to trigger cases
+			// where the cache is both used and filled.
+			d.cache = make([]cfilter, 3)
+
+			th := &testHarness{
+				d:     d,
+				TB:    t,
+				miner: miner,
+				vw:    vw,
+			}
+			tc.f(th)
+		})
+		if !succ {
+			break
+		}
+	}
+}
+
+// BenchmarkDcrwalletCSDriver benchmarks a series of GetCFilter calls.
+//
+// This ends up mostly testing your IO performnace. Note that you might want to
+// run with `-benchtime=500x` to prevent the benchmark runtime from generating
+// a large N (and therefore a large chain).
+func BenchmarkDcrwalletCSDriver(b *testing.B) {
+	miner, vw, tearDownMiner := setupTestChain(b, "dcrwallet-bench-csd")
+	defer tearDownMiner()
+
+	rpcConfig := miner.RPCConfig()
+	w, tearDownWallet := testutils.NewSyncingTestWallet(b, &rpcConfig)
+	defer tearDownWallet()
+
+	d := NewDcrwalletCSDriver(w)
+	th := &testHarness{
+		d:     d,
+		TB:    b,
+		miner: miner,
+		vw:    vw,
+	}
+
+	_, tipHeight, err := th.miner.Node.GetBestBlock(context.Background())
+	if err != nil {
+		th.Fatal(err)
+	}
+
+	targetBlockCount := int32(b.N)
+	if int32(tipHeight) < targetBlockCount {
+		th.generate(uint32(targetBlockCount - int32(tipHeight)))
+	}
+
+	ctxt, cancel := context.WithTimeout(context.Background(), defaultTimeout*5)
+	defer cancel()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for height := int32(0); height < targetBlockCount; height++ {
+		_, _, _, err := d.GetCFilter(ctxt, height)
+		if err != nil {
+			th.Fatalf("unable to get cfilter: %v", err)
+		}
+	}
+}

--- a/chainscan/csdrivers/log.go
+++ b/chainscan/csdrivers/log.go
@@ -1,0 +1,28 @@
+package csdrivers
+
+import (
+	"github.com/decred/dcrlnd/build"
+	"github.com/decred/slog"
+)
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log slog.Logger
+
+func init() {
+	UseLogger(build.NewSubLogger("CSDR", nil))
+}
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	UseLogger(slog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using slog.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/chainscan/csdrivers/remotedcrwdriver.go
+++ b/chainscan/csdrivers/remotedcrwdriver.go
@@ -1,0 +1,331 @@
+package csdrivers
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"time"
+
+	"decred.org/dcrwallet/rpc/walletrpc"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/gcs/v2"
+	"github.com/decred/dcrd/gcs/v2/blockcf2"
+	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrlnd/chainscan"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type RemoteWalletCSDriver struct {
+	wsvc walletrpc.WalletServiceClient
+	nsvc walletrpc.NetworkServiceClient
+
+	mtx      sync.Mutex
+	ereaders []*eventReader
+
+	// The following are members that define a cfilter cache which is
+	// useful to reduce db contention by reading cfilters in batches.
+	cache            []cfilter
+	cacheStartHeight int32
+}
+
+// Type assertions to ensure the driver fulfills the correct interfaces.
+var _ chainscan.HistoricalChainSource = (*RemoteWalletCSDriver)(nil)
+var _ chainscan.TipChainSource = (*RemoteWalletCSDriver)(nil)
+
+func NewRemoteWalletCSDriver(wsvc walletrpc.WalletServiceClient, nsvc walletrpc.NetworkServiceClient) *RemoteWalletCSDriver {
+	return &RemoteWalletCSDriver{
+		wsvc:  wsvc,
+		nsvc:  nsvc,
+		cache: make([]cfilter, 0, cacheCapHint),
+	}
+}
+
+func (d *RemoteWalletCSDriver) signalEventReaders(e chainscan.ChainEvent) {
+	d.mtx.Lock()
+	readers := d.ereaders
+	d.mtx.Unlock()
+
+	for _, er := range readers {
+		select {
+		case <-er.ctx.Done():
+		case er.c <- e:
+		}
+	}
+}
+
+func (d *RemoteWalletCSDriver) singleCFilter(ctx context.Context, hash *chainhash.Hash) ([16]byte, *gcs.FilterV2, error) {
+	req := &walletrpc.GetCFiltersRequest{
+		StartingBlockHash: hash[:],
+		EndingBlockHash:   hash[:],
+	}
+
+	stream, err := d.wsvc.GetCFilters(ctx, req)
+	if err != nil {
+		return [16]byte{}, nil, err
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		return [16]byte{}, nil, err
+	}
+	var key [16]byte
+
+	filter, err := gcs.FromBytesV2(blockcf2.B, blockcf2.M, resp.Filter)
+	if err != nil {
+		return key, nil, err
+	}
+
+	copy(key[:], resp.Key)
+
+	return key, filter, nil
+}
+
+func (d *RemoteWalletCSDriver) Run(ctx context.Context) error {
+	req := &walletrpc.TransactionNotificationsRequest{}
+	stream, err := d.wsvc.TransactionNotifications(ctx, req)
+	if err != nil {
+		return err
+	}
+
+nextntfn:
+	for {
+		var resp *walletrpc.TransactionNotificationsResponse
+		resp, err = stream.Recv()
+		if err != nil {
+			break
+		}
+
+		for _, b := range resp.DetachedBlockHeaders {
+			var hash, prevHash *chainhash.Hash
+			hash, err = chainhash.NewHash(b.Hash)
+			if err != nil {
+				break nextntfn
+			}
+			prevHash, err = chainhash.NewHash(b.PrevBlock)
+			if err != nil {
+				break nextntfn
+			}
+
+			e := chainscan.BlockDisconnectedEvent{
+				Hash:     *hash,
+				Height:   b.Height,
+				PrevHash: *prevHash,
+			}
+
+			d.signalEventReaders(e)
+		}
+
+		for _, bl := range resp.AttachedBlocks {
+			// Shouldn't happen, but play it safe.
+			if bl.Height <= 0 {
+				continue
+			}
+
+			var hash, prevHash *chainhash.Hash
+			hash, err = chainhash.NewHash(bl.Hash)
+			if err != nil {
+				break nextntfn
+			}
+			prevHash, err = chainhash.NewHash(bl.PrevBlock)
+			if err != nil {
+				break nextntfn
+			}
+
+			var cfKey [16]byte
+			var filter *gcs.FilterV2
+			cfKey, filter, err = d.singleCFilter(ctx, hash)
+			if err != nil {
+				break nextntfn
+			}
+
+			e := chainscan.BlockConnectedEvent{
+				PrevHash: *prevHash,
+				Hash:     *hash,
+				Height:   bl.Height,
+				CFKey:    cfKey,
+				Filter:   filter,
+			}
+			d.signalEventReaders(e)
+		}
+	}
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		log.Tracef("RemoteWalletCSDriver run context done: %v", err)
+	} else if err != nil {
+		log.Errorf("RemoteWalletCSDriver run errored: %v", err)
+	}
+	return err
+}
+
+func (d *RemoteWalletCSDriver) ChainEvents(ctx context.Context) <-chan chainscan.ChainEvent {
+	er := &eventReader{
+		ctx: ctx,
+		c:   make(chan chainscan.ChainEvent),
+	}
+	d.mtx.Lock()
+	d.ereaders = append(d.ereaders, er)
+	d.mtx.Unlock()
+
+	return er.c
+}
+
+func (d *RemoteWalletCSDriver) GetBlock(ctx context.Context, bh *chainhash.Hash) (*wire.MsgBlock, error) {
+	var (
+		resp *walletrpc.GetRawBlockResponse
+		err  error
+	)
+
+	req := &walletrpc.GetRawBlockRequest{
+		BlockHash: bh[:],
+	}
+
+	// If the response error code is 'Unavailable' it means the wallet
+	// isn't connected to any peers while in SPV mode. In that case, wait a
+	// bit and try again.
+	for stop := false; !stop; {
+		resp, err = d.nsvc.GetRawBlock(ctx, req)
+		switch {
+		case status.Code(err) == codes.Unavailable:
+			log.Warnf("Network unavailable from wallet; will try again in 5 seconds")
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(5 * time.Second):
+			}
+		case err != nil:
+			return nil, err
+		default:
+			stop = true
+		}
+	}
+
+	bl := &wire.MsgBlock{}
+	err = bl.FromBytes(resp.Block)
+	if err != nil {
+		return nil, err
+	}
+
+	return bl, nil
+}
+
+func (d *RemoteWalletCSDriver) CurrentTip(ctx context.Context) (*chainhash.Hash, int32, error) {
+	resp, err := d.wsvc.BestBlock(ctx, &walletrpc.BestBlockRequest{})
+	if err != nil {
+		return nil, 0, err
+	}
+	bh, err := chainhash.NewHash(resp.Hash)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return bh, int32(resp.Height), nil
+}
+
+// GetCFilter is part of the chainscan.HistoricalChainSource interface.
+//
+// NOTE: The returned chainhash pointer is not safe for storage as it belongs
+// to a cache entry. This is fine for use on a chainscan.Historical scanner
+// since it never stores or leaks the pointer itself.
+func (d *RemoteWalletCSDriver) GetCFilter(ctx context.Context, height int32) (*chainhash.Hash, [16]byte, *gcs.FilterV2, error) {
+	// Fast track when data is in memory.
+	if height >= d.cacheStartHeight && height < d.cacheStartHeight+int32(len(d.cache)) {
+		i := int(height - d.cacheStartHeight)
+		c := &d.cache[i]
+		return &c.hash, c.key, c.filter, nil
+	}
+
+	// Use a new ctx so we can canel halfway through.
+	ctxReq, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Read a bunch of CFilters in one go since we're likely to be
+	// requested the next few ones.
+	d.cache = d.cache[:cap(d.cache)]
+	i := 0
+
+tryconn:
+	for {
+		req := &walletrpc.GetCFiltersRequest{
+			StartingBlockHeight: height + int32(i),
+		}
+
+		if i != 0 {
+			log.Tracef("Attempting to refetch at %d",
+				req.StartingBlockHeight)
+		}
+
+		stream, err := d.wsvc.GetCFilters(ctxReq, req)
+		if status.Code(err) == codes.Unavailable {
+			// Wallet may be temporarily offline. Backoff and try
+			// again in a bit.
+			select {
+			case <-time.After(time.Second):
+				continue
+			case <-ctx.Done():
+				return nil, [16]byte{}, nil, ctx.Err()
+			}
+		}
+		if err != nil {
+			return nil, [16]byte{}, nil, err
+		}
+		for {
+			var key [16]byte
+			resp, err := stream.Recv()
+			if errors.Is(err, io.EOF) {
+				break tryconn
+			} else if status.Code(err) == codes.Unavailable {
+				log.Tracef("Broke connection at height %d",
+					req.StartingBlockHeight+int32(i))
+				continue tryconn
+			} else if err != nil {
+				return nil, key, nil, err
+			}
+
+			bh, err := chainhash.NewHash(resp.BlockHash)
+			if err != nil {
+				return nil, key, nil, err
+			}
+
+			filter, err := gcs.FromBytesV2(blockcf2.B, blockcf2.M, resp.Filter)
+			if err != nil {
+				return nil, key, nil, err
+			}
+			copy(key[:], resp.Key)
+
+			d.cache[i] = cfilter{
+				hash:   *bh,
+				height: height + int32(i),
+				key:    key,
+				filter: filter,
+			}
+
+			// Stop if the cache has been filled.
+			i++
+			if i >= cap(d.cache) {
+				break tryconn
+			}
+		}
+	}
+
+	// If we didn't read any filters from the db, it means we were
+	// requested a filter past the current mainchain tip. Inform the
+	// appropriate error in this case.
+	if i == 0 {
+		return nil, [16]byte{}, nil, chainscan.ErrBlockAfterTip{Height: height}
+	}
+
+	// Clear out unused entries so we don't keep a reference to the filters
+	// forever.
+	for j := i; j < cap(d.cache); j++ {
+		d.cache[j].filter = nil
+	}
+
+	// Keep track of correct cache start and size.
+	d.cache = d.cache[:i]
+	d.cacheStartHeight = height
+
+	// The desired filter is the first one.
+	c := &d.cache[0]
+	return &c.hash, c.key, c.filter, nil
+}

--- a/chainscan/examples/dcrdhistorical/main.go
+++ b/chainscan/examples/dcrdhistorical/main.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/chaincfg/v2"
+	"github.com/decred/dcrd/dcrutil/v3"
+	"github.com/decred/dcrd/gcs/v2"
+	"github.com/decred/dcrd/rpcclient/v6"
+	"github.com/decred/dcrd/txscript/v3"
+	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrlnd/chainscan"
+	"github.com/jessevdk/go-flags"
+)
+
+type config struct {
+	RPCUser    string   `short:"u" long:"rpcuser" description:"Username for RPC connections"`
+	RPCPass    string   `short:"P" long:"rpcpass" description:"Password for RPC connections"`
+	RPCCert    string   `long:"rpccert" description:"File containing the certificate file"`
+	RPCConnect string   `short:"c" long:"rpcconnect" description:"Network address of dcrd RPC server"`
+	TestNet    bool     `long:"testnet" description:"Use the test network"`
+	Targets    []string `short:"t" long:"target" description:"Target address to search for. Can be multiple."`
+}
+
+type dcrdConfig struct {
+	RPCUser string `short:"u" long:"rpcuser" description:"Username for RPC connections"`
+	RPCPass string `short:"P" long:"rpcpass" description:"Password for RPC connections"`
+	RPCCert string `long:"rpccert" description:"File containing the certificate file"`
+	TestNet bool   `long:"testnet" description:"Use the test network"`
+}
+
+// dcrdChainSource implements a HistoricalChainSource that fetches data from an
+// rpc client connected to a dcrd instance.
+type dcrdChainSource struct {
+	c *rpcclient.Client
+}
+
+func (s *dcrdChainSource) GetCFilter(ctx context.Context, height int32) (*chainhash.Hash, [16]byte, *gcs.FilterV2, error) {
+	var cfkey [16]byte
+
+	bh, err := s.c.GetBlockHash(ctx, int64(height))
+	if err != nil {
+		return nil, cfkey, nil, err
+	}
+
+	head, err := s.c.GetBlockHeader(ctx, bh)
+	if err != nil {
+		return nil, cfkey, nil, err
+	}
+
+	// No need to check for proof inclusion of the cfilter in the header
+	// since we trust this dcrd instance, but on SPV clients this would be
+	// needed when fetching via the P2P network.
+	cf, err := s.c.GetCFilterV2(ctx, bh)
+	if err != nil {
+		return nil, cfkey, nil, err
+	}
+
+	if height%10000 == 0 {
+		log.Printf("Fetched CFilter for block height %d", height)
+	}
+
+	copy(cfkey[:], head.MerkleRoot[:])
+	return bh, cfkey, cf.Filter, nil
+}
+
+func (s *dcrdChainSource) GetBlock(ctx context.Context, bh *chainhash.Hash) (*wire.MsgBlock, error) {
+	bl, err := s.c.GetBlock(ctx, bh)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("Fetched block for height %d", bl.Header.Height)
+	return bl, err
+}
+
+func (s *dcrdChainSource) CurrentTip(ctx context.Context) (*chainhash.Hash, int32, error) {
+	bh, h, err := s.c.GetBestBlock(ctx)
+	return bh, int32(h), err
+}
+
+func main() {
+	dcrdHomeDir := dcrutil.AppDataDir("dcrd", false)
+	opts := &config{
+		RPCCert: filepath.Join(dcrdHomeDir, "rpc.cert"),
+	}
+	dcrdCfgFile := filepath.Join(dcrdHomeDir, "dcrd.conf")
+	if _, err := os.Stat(dcrdCfgFile); err == nil {
+		// ~/.dcrd/dcrd.conf exists. Read precfg data from it.
+		dcrdOpts := &dcrdConfig{}
+		parser := flags.NewParser(dcrdOpts, flags.Default)
+		err := flags.NewIniParser(parser).ParseFile(dcrdCfgFile)
+		if err == nil {
+			opts.RPCUser = dcrdOpts.RPCUser
+			opts.RPCPass = dcrdOpts.RPCPass
+			switch {
+			case dcrdOpts.TestNet:
+				opts.RPCConnect = "localhost:19109"
+				opts.TestNet = true
+			default:
+				opts.RPCConnect = "localhost:9109"
+			}
+		}
+	}
+
+	parser := flags.NewParser(opts, flags.Default)
+	_, err := parser.Parse()
+	if err != nil {
+		var e *flags.Error
+		if errors.As(err, &e) && e.Type == flags.ErrHelp {
+			os.Exit(0)
+		}
+		parser.WriteHelp(os.Stderr)
+		return
+	}
+
+	params := chaincfg.MainNetParams()
+	if opts.TestNet {
+		params = chaincfg.TestNet3Params()
+	}
+
+	if len(opts.Targets) == 0 {
+		log.Fatal("Specify at least one target address")
+	}
+
+	// Connect to local dcrd RPC server using websockets.
+	certs, err := ioutil.ReadFile(opts.RPCCert)
+	if err != nil {
+		log.Fatal(err)
+	}
+	connCfg := &rpcclient.ConnConfig{
+		Host:         opts.RPCConnect,
+		Endpoint:     "ws",
+		User:         opts.RPCUser,
+		Pass:         opts.RPCPass,
+		Certificates: certs,
+	}
+	client, err := rpcclient.New(connCfg, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_, bestHeight, err := client.GetBestBlock(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Searching up to height %d", bestHeight)
+	startTime := time.Now()
+
+	var targets []chainscan.TargetAndOptions
+	for _, t := range opts.Targets {
+		addr, err := dcrutil.DecodeAddress(t, params)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		script, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		foundCb := func(e chainscan.Event, findMore chainscan.FindFunc) {
+			outp := wire.OutPoint{
+				Hash:  e.Tx.TxHash(),
+				Index: uint32(e.Index),
+				Tree:  e.Tree,
+			}
+			log.Printf("Found addr %s mined at block %d (output %s)",
+				t, e.BlockHeight, outp)
+
+			foundSpendCb := func(es chainscan.Event, _ chainscan.FindFunc) {
+				log.Printf("Found addr %s (outpoint %s) spent at block %d (input %s:%d)",
+					t, outp, es.BlockHeight,
+					es.Tx.TxHash(), es.Index)
+			}
+			findMore(
+				chainscan.SpentOutPoint(outp, 0, script),
+				chainscan.WithFoundCallback(foundSpendCb),
+				chainscan.WithEndHeight(int32(bestHeight)),
+			)
+		}
+
+		target := chainscan.TargetAndOptions{
+			Target: chainscan.ConfirmedScript(0, script),
+			Options: []chainscan.Option{
+				chainscan.WithFoundCallback(foundCb),
+				chainscan.WithEndHeight(int32(bestHeight)),
+			},
+		}
+		targets = append(targets, target)
+	}
+
+	completeChan := make(chan struct{})
+	targets[0].Options = append(targets[0].Options, chainscan.WithCompleteChan(completeChan))
+
+	chainSrc := &dcrdChainSource{c: client}
+	hist := chainscan.NewHistorical(chainSrc)
+	histCtx, cancel := context.WithCancel(context.Background())
+	go hist.Run(histCtx)
+
+	hist.FindMany(targets)
+	<-completeChan
+
+	endTime := time.Now()
+	log.Printf("Completed search in %s", endTime.Sub(startTime))
+
+	cancel()
+	client.Shutdown()
+}

--- a/chainscan/examples/dcrwallethistorical/main.go
+++ b/chainscan/examples/dcrwallethistorical/main.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"decred.org/dcrwallet/rpc/walletrpc"
+	"github.com/decred/dcrd/chaincfg/v2"
+	"github.com/decred/dcrd/dcrutil/v3"
+	"github.com/decred/dcrd/txscript/v3"
+	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrlnd/chainscan"
+	"github.com/decred/dcrlnd/chainscan/csdrivers"
+	"github.com/jessevdk/go-flags"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+type config struct {
+	RPCCert    string   `long:"rpccert" description:"File containing the certificate file"`
+	RPCConnect string   `short:"c" long:"rpcconnect" description:"Network address of dcrd RPC server"`
+	TestNet    bool     `long:"testnet" description:"Use the test network"`
+	Targets    []string `short:"t" long:"target" description:"Target address to search for. Can be multiple."`
+}
+
+type dcrwConfig struct {
+	RPCCert string `long:"rpccert" description:"File containing the certificate file"`
+	TestNet bool   `long:"testnet" description:"Use the test network"`
+}
+
+func main() {
+	dcrwHomeDir := dcrutil.AppDataDir("dcrwallet", false)
+	opts := &config{
+		RPCCert: filepath.Join(dcrwHomeDir, "rpc.cert"),
+	}
+	dcrwCfgFile := filepath.Join(dcrwHomeDir, "dcrwallet.conf")
+	if _, err := os.Stat(dcrwCfgFile); err == nil {
+		// ~/.dcrwallet/dcrwallet.conf exists. Read precfg data from
+		// it.
+		dcrwOpts := &dcrwConfig{}
+		parser := flags.NewParser(dcrwOpts, flags.Default)
+		err := flags.NewIniParser(parser).ParseFile(dcrwCfgFile)
+		if err == nil {
+			switch {
+			case dcrwOpts.TestNet:
+				opts.RPCConnect = "localhost:19111"
+				opts.TestNet = true
+			default:
+				opts.RPCConnect = "localhost:9111"
+			}
+		}
+	}
+
+	parser := flags.NewParser(opts, flags.Default)
+	_, err := parser.Parse()
+	if err != nil {
+		var e *flags.Error
+		if errors.As(err, &e) && e.Type == flags.ErrHelp {
+			os.Exit(0)
+		}
+		parser.WriteHelp(os.Stderr)
+		return
+	}
+
+	params := chaincfg.MainNetParams()
+	if opts.TestNet {
+		params = chaincfg.TestNet3Params()
+	}
+
+	if len(opts.Targets) == 0 {
+		log.Fatal("Specify at least one target address")
+	}
+
+	// Connect to local dcrwallet gRPC server using websockets.
+	creds, err := credentials.NewClientTLSFromFile(opts.RPCCert, "localhost")
+	if err != nil {
+		log.Fatalf("Error creating credentials: %v", err)
+
+	}
+	conn, err := grpc.Dial(opts.RPCConnect, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		log.Fatalf("Error connecting to dcrwallet's gRPC: %v", err)
+	}
+	defer conn.Close()
+
+	w := walletrpc.NewWalletServiceClient(conn)
+	n := walletrpc.NewNetworkServiceClient(conn)
+	resp, err := w.BestBlock(context.Background(), &walletrpc.BestBlockRequest{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	bestHeight := int32(resp.Height)
+	log.Printf("Searching up to height %d", bestHeight)
+	startTime := time.Now()
+
+	var targets []chainscan.TargetAndOptions
+	for _, t := range opts.Targets {
+		addr, err := dcrutil.DecodeAddress(t, params)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		script, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		foundCb := func(e chainscan.Event, findMore chainscan.FindFunc) {
+			outp := wire.OutPoint{
+				Hash:  e.Tx.TxHash(),
+				Index: uint32(e.Index),
+				Tree:  e.Tree,
+			}
+			log.Printf("Found addr %s mined at block %d (output %s)",
+				t, e.BlockHeight, outp)
+
+			foundSpendCb := func(es chainscan.Event, _ chainscan.FindFunc) {
+				log.Printf("Found addr %s (outpoint %s) spent at block %d (input %s:%d)",
+					t, outp, es.BlockHeight,
+					es.Tx.TxHash(), es.Index)
+			}
+			findMore(
+				chainscan.SpentOutPoint(outp, 0, script),
+				chainscan.WithFoundCallback(foundSpendCb),
+				chainscan.WithEndHeight(int32(bestHeight)),
+			)
+		}
+
+		target := chainscan.TargetAndOptions{
+			Target: chainscan.ConfirmedScript(0, script),
+			Options: []chainscan.Option{
+				chainscan.WithFoundCallback(foundCb),
+				chainscan.WithEndHeight(int32(bestHeight)),
+			},
+		}
+		targets = append(targets, target)
+	}
+
+	completeChan := make(chan struct{})
+	targets[0].Options = append(targets[0].Options, chainscan.WithCompleteChan(completeChan))
+
+	chainSrc := csdrivers.NewRemoteWalletCSDriver(w, n)
+	hist := chainscan.NewHistorical(chainSrc)
+	histCtx, cancel := context.WithCancel(context.Background())
+	go func() {
+		err := hist.Run(histCtx)
+		select {
+		case <-histCtx.Done():
+		default:
+			log.Printf("Historical run errored: %v", err)
+			close(completeChan)
+		}
+	}()
+
+	hist.FindMany(targets)
+	<-completeChan
+
+	endTime := time.Now()
+	log.Printf("Completed search in %s", endTime.Sub(startTime))
+
+	cancel()
+}

--- a/chainscan/historical.go
+++ b/chainscan/historical.go
@@ -1,0 +1,375 @@
+package chainscan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/gcs/v2"
+)
+
+type HistoricalChainSource interface {
+	ChainSource
+
+	// GetCFilter MUST return the block hash, key and filter for the given
+	// mainchain block height.
+	//
+	// If a height higher than the current mainchain tip is specified, the
+	// chain source MUST return ErrBlockAfterTip so that the historical
+	// scanner will correctly handle targets specified with an invalid
+	// ending height.
+	GetCFilter(context.Context, int32) (*chainhash.Hash, [16]byte, *gcs.FilterV2, error)
+}
+
+type Historical struct {
+	mtx sync.Mutex
+	ctx context.Context
+
+	newTargetsChan chan []*target
+	newTargetCount int64
+
+	// nextBatchTargets are the targets which startHeight have already
+	// passed the current height of the batch and will need to be included
+	// in the next batch.
+	nextBatchTargets []*target
+
+	chain HistoricalChainSource
+}
+
+func NewHistorical(chain HistoricalChainSource) *Historical {
+	return &Historical{
+		chain:          chain,
+		newTargetsChan: make(chan []*target),
+	}
+}
+
+// nextBatchRun returns the next run for the given batch of targets.  The batch
+// is modified so that targets left out of this run remain on it.
+func nextBatchRun(batch *targetHeap) *targetHeap {
+	if len(*batch) == 0 {
+		return &targetHeap{}
+	}
+
+	// Begin a new run.
+	run := &targetHeap{batch.pop()}
+	startHeight := run.peak().startHeight
+
+	// Find all items that have the same startHeight.
+	for t := batch.peak(); t != nil && t.startHeight == startHeight; t = batch.peak() {
+		run.push(batch.pop())
+	}
+	return run
+}
+
+func targetsForNextBatch(height int32, newTargets []*target) ([]*target, []*target) {
+	var thisBatch, nextBatch []*target
+	for _, nt := range newTargets {
+		switch {
+		case nt.startHeight <= height:
+			log.Tracef("New target delayed to next batch due to %d <= %d",
+				nt.startHeight, height)
+			nextBatch = append(nextBatch, nt)
+
+		default:
+			thisBatch = append(thisBatch, nt)
+		}
+	}
+
+	return thisBatch, nextBatch
+}
+
+func (h *Historical) drainNewTargets(waiting []*target) ([]*target, error) {
+	var zeroEndHeight bool
+
+	// Determine if any of the outstanding waiting targets has zero
+	// endHeight.
+	for _, t := range waiting {
+		if t.endHeight > 0 {
+			continue
+		}
+		zeroEndHeight = true
+		break
+	}
+
+	// While there are outstanding new targets to be received, block while
+	// waiting for them so we can decide what to do (add to the current
+	// batch or keep it until the next batch starts).
+	for atomic.LoadInt64(&h.newTargetCount) > 0 {
+		select {
+		case <-h.ctx.Done():
+			return nil, h.ctx.Err()
+		case newTargets := <-h.newTargetsChan:
+			waiting = append(waiting, newTargets...)
+			atomic.AddInt64(&h.newTargetCount, -1)
+
+			// If we haven't determined there are targets with an
+			// endHeight with a zero value, verify this new batch.
+			if zeroEndHeight {
+				continue
+			}
+			for _, nt := range newTargets {
+				if nt.endHeight <= 0 {
+					zeroEndHeight = true
+					break
+				}
+			}
+
+		}
+	}
+
+	// If there are new targets with a zero endHeight, fetch the current
+	// tip and fill their endHeight.
+	if zeroEndHeight {
+		_, endHeight, err := h.chain.CurrentTip(h.ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, nt := range waiting {
+			if nt.endHeight <= 0 {
+				nt.endHeight = endHeight
+			}
+		}
+	}
+
+	return waiting, nil
+}
+
+// rescanRun performs the rescan across a single "run" of targets in ascending
+// block height.
+func (h *Historical) rescanRun(targets *targetList, batch *targetHeap, startHeight int32) error {
+	var (
+		bcf blockCFilter
+		err error
+	)
+
+	log.Tracef("Starting run with %d targets at height %d", len(targets.targets),
+		startHeight)
+
+	for bcf.height = startHeight; !targets.empty(); bcf.height++ {
+		if h.ctxDone() {
+			return h.ctx.Err()
+		}
+
+		// Fetch cfilter for this block & process it.
+		bcf.hash, bcf.cfilterKey, bcf.cfilter, err = h.chain.GetCFilter(h.ctx, bcf.height)
+		if err != nil {
+			if errors.Is(err, ErrBlockAfterTip{}) {
+				// This means at least one target was specified
+				// with an endHeight past the current tip or
+				// we're in the middle of a reorg. In any case,
+				// this isn't a critical error as specified in
+				// the documentation for this scanner.
+				//
+				// Signal all targets as complete.
+				signalComplete(targets.removeAll())
+				return nil
+			}
+			return err
+		}
+
+		err = scan(h.ctx, &bcf, targets, h.chain.GetBlock)
+		if err != nil {
+			return err
+		}
+
+		// Fetch and split new targets between those that can be
+		// processed in this batch and those that will need to wait for
+		// the next batch.
+		newTargets, err := h.drainNewTargets(nil)
+		if err != nil {
+			return err
+		}
+		thisBatch, nextBatch := targetsForNextBatch(bcf.height, newTargets)
+		batch.push(thisBatch...)
+		h.nextBatchTargets = append(h.nextBatchTargets, nextBatch...)
+
+		// Add any targets that can extend this run.
+		for t := batch.peak(); t != nil && t.startHeight == bcf.height+1; t = batch.peak() {
+			targets.add(batch.pop())
+			log.Tracef("Added target to run at height %d: %s",
+				bcf.height, t)
+
+		}
+
+		// Remove canceled and targets which reached their endHeight
+		// and signal their completion.
+		stale := targets.removeStale(bcf.height)
+		signalComplete(stale)
+
+		if targets.dirty {
+			targets.rebuildCfilterEntries()
+		}
+	}
+
+	log.Tracef("Ended run at height %d", bcf.height-1)
+	return nil
+}
+
+// rescanBatch performs a rescan across all outstanding targets (a "batch" of
+// targets) in ascending block height order.
+//
+// A batch may be composed of multiple disjoint "runs".
+func (h *Historical) rescanBatch(targets []*target) error {
+	batch := asTargetHeap(targets)
+
+	log.Debugf("Starting batch of %d targets", len(targets))
+
+	tl := newTargetList(nil)
+	for batch.peak() != nil {
+		run := nextBatchRun(batch)
+		startHeight := run.peak().startHeight
+		tl.add(*run...)
+		tl.rebuildCfilterEntries()
+		err := h.rescanRun(tl, batch, startHeight)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *Historical) Run(ctx context.Context) error {
+	h.mtx.Lock()
+	if h.ctx != nil {
+		h.mtx.Unlock()
+		return errors.New("already running")
+	}
+	h.ctx = ctx
+	h.mtx.Unlock()
+
+	var err error
+
+	for {
+		// Process any existing waiting targets or wait for some to
+		// arrive.
+		newTargets := h.nextBatchTargets
+		h.nextBatchTargets = nil
+		if len(newTargets) == 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case newTargets = <-h.newTargetsChan:
+				atomic.AddInt64(&h.newTargetCount, -1)
+			}
+		}
+		newTargets, err = h.drainNewTargets(newTargets)
+		if err != nil {
+			return err
+		}
+
+		err = h.rescanBatch(newTargets)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// applyOptions applies the given options to the given target and returns the
+// concrete implementation of the target or an error.
+//
+// This is used to ensure the same validation rules are used in both Find and
+// FindMany.
+func (h *Historical) applyOptions(tgt Target, opts []Option) (*target, error) {
+	t, ok := tgt.(*target)
+	if !ok {
+		return nil, errors.New("provided target should be chainscan.*target")
+	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	if t.endHeight > 0 && t.endHeight < t.startHeight {
+		return nil, errors.New("malformed query (endHeight < startHeight)")
+	}
+
+	return t, nil
+}
+
+// ctxDone returns true when the historical's ctx is both filled and Done().
+func (h *Historical) ctxDone() bool {
+	h.mtx.Lock()
+	ctx := h.ctx
+	h.mtx.Unlock()
+	if ctx == nil {
+		return false
+	}
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *Historical) Find(tgt Target, opts ...Option) error {
+	if h.ctxDone() {
+		return errors.New("historical scanner finished running")
+	}
+
+	t, err := h.applyOptions(tgt, opts)
+	if err != nil {
+		return err
+	}
+
+	// We're about to add new targets, so setup the flag that will let the
+	// batch processor know to wait for them.
+	newCount := atomic.AddInt64(&h.newTargetCount, 1)
+	if newCount < 0 {
+		// How did we wrap around an int64? This is super bad.
+		panic(fmt.Errorf("wrap around newTargetCount"))
+	}
+
+	// Signal the existance of new targets in a new goroutine to avoid
+	// locking.
+	go func() {
+		h.newTargetsChan <- []*target{t}
+	}()
+
+	return nil
+}
+
+// FindMany attempts to search for many targets at once. This is better than
+// making individual calls to Find() when they should be searched for at the
+// same starting height since all specified targets are guaranteed to be
+// included in the same search batch.
+//
+// This function is safe for concurrent calls in multiple goroutines, including
+// inside functions specified with WithFoundCallback() options.
+func (h *Historical) FindMany(targets []TargetAndOptions) error {
+	if h.ctxDone() {
+		return errors.New("historical scanner finished running")
+	}
+
+	ts := make([]*target, len(targets))
+	var err error
+
+	for i, tgt := range targets {
+		ts[i], err = h.applyOptions(tgt.Target, tgt.Options)
+		if err != nil {
+			return err
+		}
+	}
+
+	// We're about to add new targets, so setup the flag that will let the
+	// batch processor know to wait for them.
+	newCount := atomic.AddInt64(&h.newTargetCount, 1)
+	if newCount < 0 {
+		// How did we wrap around an int64? This is super bad.
+		panic(fmt.Errorf("wrap around newTargetCount"))
+	}
+
+	// Signal the existance of new targets in a new goroutine to avoid
+	// locking.
+	go func() {
+		h.newTargetsChan <- ts
+	}()
+
+	return nil
+
+}

--- a/chainscan/historical_test.go
+++ b/chainscan/historical_test.go
@@ -1,0 +1,1180 @@
+package chainscan
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/decred/dcrd/wire"
+)
+
+type histTestCtx struct {
+	chain  *mockChain
+	hist   *Historical
+	cancel func()
+	t      testingIntf
+}
+
+func newHistTestCtx(t testingIntf) *histTestCtx {
+	ctx, cancel := context.WithCancel(context.Background())
+	chain := newMockChain()
+	hist := NewHistorical(chain)
+	chain.extend(chain.newFromTip()) // Genesis block
+
+	go func() {
+		hist.Run(ctx)
+	}()
+
+	return &histTestCtx{
+		chain:  chain,
+		hist:   hist,
+		cancel: cancel,
+		t:      t,
+	}
+}
+
+func (h *histTestCtx) cleanup() {
+	h.cancel()
+}
+
+func (h *histTestCtx) genBlocks(n int, allCfiltersMatch bool) {
+	h.t.Helper()
+	var manglers []blockMangler
+
+	if allCfiltersMatch {
+		manglers = append(manglers, cfilterData(testPkScript))
+	}
+
+	h.chain.genBlocks(n, manglers...)
+}
+
+// TestHistorical tests the basic behavior of the historical scanner against
+// the scannerTestCases, which must be fulfilled by both the historical and tip
+// watcher scanners.
+func TestHistorical(t *testing.T) {
+
+	runTC := func(c scannerTestCase, t *testing.T) {
+		var foundCbEvent, foundChanEvent Event
+		completeChan := make(chan struct{})
+		foundChan := make(chan Event)
+		tc := newHistTestCtx(t)
+		defer tc.cleanup()
+
+		// The generated test chain is:
+		// - 5 blocks that miss the cfilter match
+		// - 5 blocks with a cfilter match
+		// - block with test case manglers
+		// - 5 blocks with a cfilter match
+		tc.genBlocks(5, false)
+		tc.genBlocks(5, true)
+		b := tc.chain.newFromTip(c.manglers...)
+		tc.chain.extend(b)
+		tc.genBlocks(5, true)
+
+		assertNoError(t, tc.hist.Find(
+			c.target(b),
+			WithFoundCallback(func(e Event, _ FindFunc) { foundCbEvent = e }),
+			WithFoundChan(foundChan),
+			WithCompleteChan(completeChan),
+		))
+
+		// Wait until the search is complete.
+		assertCompleted(tc.t, completeChan)
+
+		if !c.wantFound {
+			// Testing when we don't expect a match.
+
+			assertFoundChanEmpty(tc.t, foundChan)
+			if foundCbEvent != emptyEvent {
+				t.Fatalf("unexpected foundCallback triggered with %s", &foundCbEvent)
+			}
+
+			// Nothing else to test since we didn't expect a match.
+			return
+		}
+
+		// Testing when we expect a match.
+
+		select {
+		case foundChanEvent = <-foundChan:
+		case <-time.After(5 * time.Second):
+			t.Fatal("found chan not triggered in time")
+		}
+
+		if foundCbEvent == emptyEvent {
+			t.Fatal("foundCallback not triggered")
+		}
+
+		if foundChanEvent != foundCbEvent {
+			t.Fatal("cb and chan showed different events")
+		}
+
+		e := foundChanEvent
+		if e.MatchedField != c.wantMF {
+			t.Fatalf("unexpected matched field. want=%s got=%s",
+				c.wantMF, e.MatchedField)
+		}
+
+		if e.BlockHeight != int32(b.block.Header.Height) {
+			t.Fatalf("unexpected matched block height. want=%d got=%d",
+				b.block.Header.Height, e.BlockHeight)
+		}
+
+		if e.BlockHash != b.block.Header.BlockHash() {
+			t.Fatalf("unexpected matched block hash. want=%s got=%s",
+				b.block.Header.BlockHash(), e.BlockHash)
+		}
+
+		// All tests always match against the first transaction in the
+		// block in either the stake or regular tx tree.
+		var tx *wire.MsgTx
+		var tree int8
+		if len(b.block.Transactions) > 0 {
+			tx = b.block.Transactions[0]
+			tree = wire.TxTreeRegular
+		} else {
+			tx = b.block.STransactions[0]
+			tree = wire.TxTreeStake
+		}
+		if e.Tx.TxHash() != tx.TxHash() {
+			t.Fatalf("unexpected tx match. want=%s got=%s",
+				b.block.Transactions[0].TxHash(), e.Tx.TxHash())
+		}
+
+		// All tests always match against the second input or output.
+		if e.Index != 1 {
+			t.Fatalf("unexpected index match. want=%d got=%d",
+				1, e.Index)
+		}
+
+		if e.Tree != tree {
+			t.Fatalf("unexpected tree match. want=%d got=%d",
+				tree, e.Tree)
+		}
+	}
+
+	for _, c := range scannerTestCases {
+		c := c
+		ok := t.Run(c.name, func(t *testing.T) { runTC(c, t) })
+		if !ok {
+			break
+		}
+	}
+}
+
+// TestHistoricalCancellation tests that cancelling the search for a target
+// before it's found makes it actually not get found.
+func TestHistoricalCancellation(t *testing.T) {
+	completeChan := make(chan struct{})
+	cancelChan := make(chan struct{})
+	foundChan := make(chan Event)
+	tc := newHistTestCtx(t)
+	defer tc.cleanup()
+
+	// The generated test chain is:
+	// - 5 blocks that miss the cfilter match
+	// - 5 blocks with a cfilter match
+	// - block with test case manglers
+	// - 5 blocks with a cfilter match
+	tc.genBlocks(5, false)
+	tc.genBlocks(5, true)
+	b := tc.chain.newFromTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	tc.chain.extend(b)
+	tc.genBlocks(5, true)
+
+	// Instrument the mock chain so we can stop the search mid-way through.
+	tc.chain.sendNextCfilterChan = make(chan struct{})
+
+	// Start the search.
+	tc.hist.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(foundChan),
+		WithCompleteChan(completeChan),
+		WithCancelChan(cancelChan),
+	)
+
+	// Allow the first 10 blocks to be scanned.
+	for i := 0; i < 10; i++ {
+		tc.chain.sendNextCfilterChan <- struct{}{}
+	}
+
+	// We don't expect the target to be found yet.
+	select {
+	case <-completeChan:
+		t.Fatal("Unexpected completeChan receive")
+	case <-foundChan:
+		t.Fatal("Unexpected foundChan receive")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	// Cancel the search.
+	close(cancelChan)
+
+	// The next cfilter may have been requested already, so we allow it to
+	// send (or wait a bit to make sure it wasn't requested).
+	select {
+	case tc.chain.sendNextCfilterChan <- struct{}{}:
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	// We don't expect neither the complete chan, foundChan or new requests
+	// for cfilters to be triggered.
+	select {
+	case <-tc.chain.sendNextCfilterChan:
+		t.Fatal("Unexpected sendNextCfilterChan receive")
+	case <-completeChan:
+		t.Fatal("Unexpected completeChan receive")
+	case <-foundChan:
+		t.Fatal("Unexpected foundChan receive")
+	default:
+	}
+}
+
+// TestHistoricalStartHeight tests that starting the search after the height
+// where the target is found makes it actually not get found.
+func TestHistoricalStartHeight(t *testing.T) {
+	completeChan := make(chan struct{})
+	foundChan := make(chan Event)
+	tc := newHistTestCtx(t)
+	defer tc.cleanup()
+
+	// The generated test chain is:
+	// - 5 blocks that miss the cfilter match
+	// - 5 blocks with a cfilter match
+	// - block with test case manglers
+	// - 5 blocks with a cfilter match
+	tc.genBlocks(5, false)
+	tc.genBlocks(5, true)
+	b := tc.chain.newFromTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	tc.chain.extend(b)
+	tc.genBlocks(5, true)
+
+	// Start the search.
+	tc.hist.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(foundChan),
+		WithCompleteChan(completeChan),
+		WithStartHeight(12),
+	)
+
+	// The completeChan should be signalled with the completion of the
+	// scan.
+	assertCompleted(t, completeChan)
+
+	// foundChan should not have been triggered.
+	assertFoundChanEmpty(t, foundChan)
+}
+
+// TestHistoricalEndHeight tests that stopping the search before the height
+// where the target is found makes it actually not get found.
+func TestHistoricalEndHeight(t *testing.T) {
+	completeChan := make(chan struct{})
+	foundChan := make(chan Event)
+	tc := newHistTestCtx(t)
+	defer tc.cleanup()
+
+	// The generated test chain is:
+	// - 5 blocks that miss the cfilter match
+	// - 5 blocks with a cfilter match
+	// - block with test case manglers
+	// - 5 blocks with a cfilter match
+	tc.genBlocks(5, false)
+	tc.genBlocks(5, true)
+	b := tc.chain.newFromTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	tc.chain.extend(b)
+	tc.genBlocks(5, true)
+
+	// Start the search.
+	tc.hist.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(foundChan),
+		WithCompleteChan(completeChan),
+		WithEndHeight(int32(b.block.Header.Height-2)),
+	)
+
+	// The completeChan should be signalled with the completion of the
+	// scan.
+	assertCompleted(t, completeChan)
+
+	// foundChan should not have been triggered.
+	assertFoundChanEmpty(t, foundChan)
+}
+
+// TestHistoricalMultipleMatchesInBlock tests that the historical search
+// correctly sends multiple events when the same script is confirmed multiple
+// times in a single block.
+func TestHistoricalMultipleMatchesInBlock(t *testing.T) {
+	completeChan := make(chan struct{})
+	foundChan := make(chan Event)
+	tc := newHistTestCtx(t)
+	defer tc.cleanup()
+
+	// The generated test chain is:
+	// - 5 blocks that miss the cfilter match
+	// - 5 blocks with a cfilter match
+	// - block with test case manglers
+	// - 5 blocks with a cfilter match
+	tc.genBlocks(5, false)
+	tc.genBlocks(5, true)
+	b := tc.chain.newFromTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	// Create an additional output.
+	b.block.Transactions[0].AddTxOut(&wire.TxOut{PkScript: testPkScript})
+
+	tc.chain.extend(b)
+	tc.genBlocks(5, true)
+
+	// Start the search.
+	tc.hist.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(foundChan),
+		WithCompleteChan(completeChan),
+	)
+
+	// The completeChan should be signalled with the completion of the
+	// scan.
+	assertCompleted(t, completeChan)
+
+	// foundChan should be triggered two (and only two) times.
+	e1 := assertFoundChanRcvHeight(t, foundChan, int32(b.block.Header.Height))
+	e2 := assertFoundChanRcvHeight(t, foundChan, int32(b.block.Header.Height))
+	assertFoundChanEmpty(t, foundChan)
+
+	// However the events should *not* be exactly the same: the script was
+	// confirmed in two different outputs.
+	if e1 == e2 {
+		t.Fatal("script confirmed twice in the same output")
+	}
+}
+
+// TestHistoricalBlockDownload tests that the historical search only downloads
+// blocks for which the cfilter has passed.
+func TestHistoricalBlockDownload(t *testing.T) {
+	completeChan := make(chan struct{})
+	tc := newHistTestCtx(t)
+	defer tc.cleanup()
+
+	// The generated test chain is:
+	// - 5 blocks that miss the cfilter match
+	// - 5 blocks with a cfilter match
+	// - block with test case manglers
+	// - 5 blocks with a cfilter match
+	tc.genBlocks(5, false)
+	tc.genBlocks(5, true)
+	b := tc.chain.newFromTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	tc.chain.extend(b)
+	tc.genBlocks(5, true)
+
+	// Perform the full search.
+	tc.hist.Find(
+		ConfirmedScript(0, testPkScript),
+		WithCompleteChan(completeChan),
+	)
+	assertCompleted(t, completeChan)
+
+	// We only expect fetches for 11 blocks of data.
+	wantGetBlockCount := uint32(11)
+	if tc.chain.getBlockCount != wantGetBlockCount {
+		t.Fatalf("Unexpected getBlockCount. want=%d got=%d",
+			wantGetBlockCount, tc.chain.getBlockCount)
+	}
+}
+
+// TestHistoricalMultipleFinds tests that performing a search with multiple
+// finds for the same target works as expected.
+func TestHistoricalMultipleFinds(t *testing.T) {
+
+	runTC := func(c scannerTestCase, t *testing.T) {
+		tc := newHistTestCtx(t)
+		defer tc.cleanup()
+
+		// The generated test chain is:
+		// - 5 blocks that miss the cfilter match
+		// - 5 blocks with a cfilter match
+		// - block with test case manglers
+		// - 5 blocks with a cfilter match
+		tc.genBlocks(5, false)
+		tc.genBlocks(5, true)
+		b := tc.chain.newFromTip(c.manglers...)
+		tc.chain.extend(b)
+		tc.genBlocks(5, true)
+
+		foundChan1 := make(chan Event)
+		foundChan2 := make(chan Event)
+
+		// Start the search.
+		tc.hist.FindMany([]TargetAndOptions{
+			{
+				Target: c.target(b),
+				Options: []Option{
+					WithFoundChan(foundChan1),
+				},
+			},
+			{
+				Target: c.target(b),
+				Options: []Option{
+					WithFoundChan(foundChan2),
+				},
+			},
+		})
+
+		// We expect one (and only one) event in each foundChan.
+		assertFoundChanRcvHeight(tc.t, foundChan1, int32(b.block.Header.Height))
+		assertFoundChanRcvHeight(tc.t, foundChan2, int32(b.block.Header.Height))
+		assertFoundChanEmpty(tc.t, foundChan1)
+		assertFoundChanEmpty(tc.t, foundChan2)
+	}
+
+	// Test against all variants of targets.
+	for _, c := range scannerTestCases {
+		if !c.wantFound {
+			continue
+		}
+		c := c
+		ok := t.Run(c.name, func(t *testing.T) { runTC(c, t) })
+		if !ok {
+			break
+		}
+	}
+}
+
+// TestHistoricalMultipleOverlap tests that starting a search with multiple
+// targets with overlapping search intervals works as expected.
+func TestHistoricalMultipleOverlap(t *testing.T) {
+
+	runTC := func(c scannerTestCase, t *testing.T) {
+		tc := newHistTestCtx(t)
+		defer tc.cleanup()
+
+		// The generated test chain is:
+		// - 5 blocks that miss the cfilter match
+		// - 5 blocks with a cfilter match
+		// - block with test case manglers
+		// - 5 blocks with a cfilter match
+		// - block with test case manglers
+		tc.genBlocks(5, false)
+		tc.genBlocks(5, true)
+		b := tc.chain.newFromTip(c.manglers...)
+		tc.chain.extend(b)
+		tc.genBlocks(5, true)
+		b2 := tc.chain.newFromTip(c.manglers...)
+		tc.chain.extend(b2)
+
+		foundChan1 := make(chan Event)
+		foundChan2 := make(chan Event)
+		completeChan1 := make(chan struct{})
+		completeChan2 := make(chan struct{})
+
+		// Start two concurrent searches with non-overlapping heights.
+		tc.hist.FindMany([]TargetAndOptions{
+			{
+				Target: c.target(b),
+				Options: []Option{
+					WithFoundChan(foundChan1),
+					WithCompleteChan(completeChan1),
+					WithEndHeight(int32(b.block.Header.Height + 2)),
+				},
+			},
+			{
+				Target: c.target(b2),
+				Options: []Option{
+					WithFoundChan(foundChan2),
+					WithCompleteChan(completeChan2),
+					WithStartHeight(int32(b.block.Header.Height + 1)),
+				},
+			},
+		})
+
+		// Wait for both searches to complete.
+		assertCompleted(tc.t, completeChan1)
+		assertCompleted(tc.t, completeChan2)
+
+		// We expect one (and only one) signall in each foundChan.
+		assertFoundChanRcvHeight(tc.t, foundChan1, int32(b.block.Header.Height))
+		assertFoundChanRcvHeight(tc.t, foundChan2, int32(b2.block.Header.Height))
+		assertFoundChanEmpty(tc.t, foundChan1)
+		assertFoundChanEmpty(tc.t, foundChan2)
+	}
+
+	// Test against all variants of targets.
+	for _, c := range scannerTestCases {
+		if !c.wantFound {
+			continue
+		}
+		c := c
+		ok := t.Run(c.name, func(t *testing.T) { runTC(c, t) })
+		if !ok {
+			break
+		}
+	}
+}
+
+// TestHistoricalMultipleNoOverlap tests that starting a search with multiple,
+// non-overlapping targets works as expected.
+func TestHistoricalMultipleNoOverlap(t *testing.T) {
+
+	runTC := func(c scannerTestCase, t *testing.T) {
+		tc := newHistTestCtx(t)
+		defer tc.cleanup()
+
+		// The generated test chain is:
+		// - 5 blocks that miss the cfilter match
+		// - 5 blocks with a cfilter match
+		// - block with test case manglers
+		// - 5 blocks with a cfilter match
+		// - block with test case manglers
+		tc.genBlocks(5, false)
+		tc.genBlocks(5, true)
+		b := tc.chain.newFromTip(c.manglers...)
+		tc.chain.extend(b)
+		tc.genBlocks(5, true)
+		b2 := tc.chain.newFromTip(c.manglers...)
+		tc.chain.extend(b2)
+
+		foundChan1 := make(chan Event)
+		foundChan2 := make(chan Event)
+		completeChan1 := make(chan struct{})
+		completeChan2 := make(chan struct{})
+
+		// Start two concurrent searches with non-overlapping heights.
+		tc.hist.FindMany([]TargetAndOptions{
+			{
+				Target: c.target(b),
+				Options: []Option{
+					WithFoundChan(foundChan1),
+					WithCompleteChan(completeChan1),
+					WithEndHeight(int32(b.block.Header.Height + 1)),
+				},
+			},
+			{
+				Target: c.target(b2),
+				Options: []Option{
+					WithFoundChan(foundChan2),
+					WithCompleteChan(completeChan2),
+					WithStartHeight(int32(b.block.Header.Height + 4)),
+				},
+			},
+		})
+
+		// Wait for both searches to complete.
+		assertCompleted(tc.t, completeChan1)
+		assertCompleted(tc.t, completeChan2)
+
+		// We expect one (and only one) signall in each foundChan.
+		assertFoundChanRcvHeight(tc.t, foundChan1, int32(b.block.Header.Height))
+		assertFoundChanRcvHeight(tc.t, foundChan2, int32(b2.block.Header.Height))
+		assertFoundChanEmpty(tc.t, foundChan1)
+		assertFoundChanEmpty(tc.t, foundChan2)
+	}
+
+	// Test against all variants of targets.
+	for _, c := range scannerTestCases {
+		if !c.wantFound {
+			continue
+		}
+		c := c
+		ok := t.Run(c.name, func(t *testing.T) { runTC(c, t) })
+		if !ok {
+			break
+		}
+	}
+}
+
+// TestHistoricalAddNewTargetDuringFcb tests that adding new targets for the
+// historical search during the call for FoundCallback by using the passed
+// function works as expected and provokes the new target to be found.
+func TestHistoricalAddNewTargetDuringFcb(t *testing.T) {
+
+	runTC := func(c scannerTestCase, t *testing.T) {
+		tc := newHistTestCtx(t)
+		defer tc.cleanup()
+
+		// The generated test chain is:
+		// - 5 blocks that miss the cfilter match
+		// - 5 blocks with a cfilter match
+		// - block with test case manglers (twice)
+		// - 5 blocks with a cfilter match
+		tc.genBlocks(5, false)
+		tc.genBlocks(5, true)
+		b := tc.chain.newFromTip(c.manglers...)
+		dupeTestTx(b)
+		tc.chain.extend(b)
+		tc.genBlocks(5, true)
+
+		foundChan := make(chan Event)
+		foundCb := func(e Event, addNew FindFunc) {
+			assertNoError(t, addNew(
+				c.target(b),
+				WithFoundChan(foundChan),
+			))
+		}
+
+		// Start the search.
+		tc.hist.Find(
+			c.target(b),
+			WithFoundCallback(foundCb),
+		)
+
+		// We expect one (and only one) event in foundChan
+		assertFoundChanRcvHeight(t, foundChan, int32(b.block.Header.Height))
+		assertFoundChanEmpty(t, foundChan)
+
+	}
+	// Test against all variants of targets.
+	for _, c := range scannerTestCases {
+		if !c.wantFound {
+			continue
+		}
+		c := c
+		ok := t.Run(c.name, func(t *testing.T) { runTC(c, t) })
+		if !ok {
+			break
+		}
+	}
+}
+
+// TestHistoricalAddNewTarget tests that adding new targets for the historical
+// search during the call for FoundCallback works as expected and provokes the
+// new target to be found.
+func TestHistoricalAddNewTarget(t *testing.T) {
+	tc := newHistTestCtx(t)
+	defer tc.cleanup()
+
+	pkScript2 := []byte{0x01, 0x02, 0x03, 0x04}
+
+	// The generated test chain is:
+	// - 5 blocks that miss the cfilter match
+	// - 5 blocks with a cfilter match
+	// - block with test case manglers
+	// - 5 blocks with a cfilter match
+	// - block with second confirmed pkscript
+	tc.genBlocks(5, false)
+	tc.genBlocks(5, true)
+	b := tc.chain.newFromTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	tc.chain.extend(b)
+	tc.genBlocks(5, true)
+	b2 := tc.chain.newFromTip(
+		confirmScript(pkScript2),
+		cfilterData(pkScript2),
+	)
+	tc.chain.extend(b2)
+
+	foundChanOld := make(chan Event)
+	foundChanNew := make(chan Event)
+	foundChanRestart := make(chan Event)
+	foundCb := func(e Event, _ FindFunc) {
+		// The foundCallback will start a new search for three
+		// different targets:
+		// - The testPkScript with startHeight of e.BlockHeight+1 which
+		// shouldn't match;
+		// - The pkScript2 with startHeight of e.BlockHeight+1 which
+		// should match;
+		// - The testPkScript with startHeight of 0 which should match.
+		tc.hist.Find(
+			ConfirmedScript(0, testPkScript),
+			WithFoundChan(foundChanOld),
+			WithStartHeight(e.BlockHeight+1),
+		)
+		tc.hist.Find(
+			ConfirmedScript(0, pkScript2),
+			WithFoundChan(foundChanNew),
+			WithStartHeight(e.BlockHeight+1),
+		)
+		tc.hist.Find(
+			ConfirmedScript(0, testPkScript),
+			WithFoundChan(foundChanRestart),
+		)
+	}
+
+	// Start the search.
+	tc.hist.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundCallback(foundCb),
+	)
+
+	// foundChanOld should be empty since the search was started at a block
+	// height higher than where the script was confirmed. The other two
+	// channels should have confirmations.
+	assertFoundChanEmpty(t, foundChanOld)
+	assertFoundChanRcvHeight(t, foundChanNew, int32(b2.block.Header.Height))
+	assertFoundChanRcvHeight(t, foundChanRestart, int32(b.block.Header.Height))
+}
+
+// TestHistoricalAddNewTargetSingleBatch tests that adding new targets for the
+// historical search during the call for FoundCallback which doesn't lead to a
+// new batch correctly causes only the current batch to be executed.
+func TestHistoricalAddNewTargetSingleBatch(t *testing.T) {
+	tc := newHistTestCtx(t)
+	defer tc.cleanup()
+
+	// The generated test chain is:
+	// - 5 blocks that miss the cfilter match
+	// - 5 blocks with a cfilter match
+	// - block with test case manglers
+	// - 5 blocks with a cfilter match
+	// - block with second confirmed pkscript
+	tc.genBlocks(5, false)
+	tc.genBlocks(5, true)
+	b := tc.chain.newFromTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	tc.chain.extend(b)
+	tc.genBlocks(5, true)
+
+	completeChan := make(chan struct{})
+	foundCb := func(e Event, _ FindFunc) {
+		// Add the new target with a start height of currentHeight+1 so
+		// that it will be added to the current batch.
+		tc.hist.Find(
+			ConfirmedScript(0, testPkScript),
+			WithCompleteChan(completeChan),
+			WithStartHeight(e.BlockHeight+1),
+		)
+	}
+
+	// Start the search.
+	tc.hist.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundCallback(foundCb),
+	)
+
+	assertCompleted(t, completeChan)
+
+	// We expect only a single batch to have taken place, so all blocks
+	// should have been downloaded only once.
+	wantGetBlockCount := uint32(11)
+	if tc.chain.getBlockCount != wantGetBlockCount {
+		t.Fatalf("Unexpected getBlockCount. want=%d got=%d",
+			wantGetBlockCount, tc.chain.getBlockCount)
+	}
+}
+
+// TestHistoricalNewTipNoOverlap tests that performing a historical search when
+// new tips of the chain are coming in behaves as expected when we create a new
+// search that does not overlap with the existing search.
+func TestHistoricalNewTipNoOverlap(t *testing.T) {
+	tc := newHistTestCtx(t)
+	defer tc.cleanup()
+
+	// Instrument the mock chain so we can stop the search half-way
+	// through.
+	tc.chain.sendNextCfilterChan = make(chan struct{})
+
+	// The generated test chain is:
+	// - 5 blocks that miss the cfilter match
+	// - 5 blocks with a cfilter match
+	// - block with test case manglers
+	// - 5 blocks with a cfilter match
+	// - block with second confirmed pkscript
+	tc.genBlocks(5, false)
+	tc.genBlocks(5, true)
+	b := tc.chain.newFromTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	tc.chain.extend(b)
+	tc.genBlocks(5, true)
+
+	// Start the search.
+	foundChan := make(chan Event)
+	tc.hist.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(foundChan),
+	)
+
+	// Let it process 3 blocks and start processing the fourth.
+	tc.chain.sendNextCfilterChan <- struct{}{}
+	tc.chain.sendNextCfilterChan <- struct{}{}
+	tc.chain.sendNextCfilterChan <- struct{}{}
+
+	// Let the blocks be processed.
+	time.Sleep(10 * time.Millisecond)
+
+	// Extend the tip with 3 new blocks, including a match of the target at
+	// the end.
+	startHeight := int32(tc.chain.tip.block.Header.Height) + 1
+	tc.genBlocks(2, true)
+	b2 := tc.chain.newFromTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	tc.chain.extend(b2)
+
+	// Start a new search which does not overlap with the previous search.
+	// The start height will be higher than the previous search's end
+	// height.
+	foundChanNew := make(chan Event)
+	completeChanNew := make(chan struct{})
+	tc.hist.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(foundChanNew),
+		WithStartHeight(startHeight),
+		WithCompleteChan(completeChanNew),
+	)
+
+	// Send as many blocks as needed until no more are requested by the
+	// scan.
+	done := false
+	for !done {
+		select {
+		case tc.chain.sendNextCfilterChan <- struct{}{}:
+		case <-time.After(10 * time.Millisecond):
+			done = true
+		}
+	}
+
+	// Wait for the second scan to wrap up.
+	assertCompleted(tc.t, completeChanNew)
+
+	// We expect one (and only one) signal in each foundChan.
+	assertFoundChanRcvHeight(tc.t, foundChan, int32(b.block.Header.Height))
+	assertFoundChanRcvHeight(tc.t, foundChanNew, int32(b2.block.Header.Height))
+	assertFoundChanEmpty(tc.t, foundChan)
+	assertFoundChanEmpty(tc.t, foundChanNew)
+}
+
+// TestHistoricalNewTipOverlap tests that performing a historical search when
+// new tips of the chain are coming in behaves as expected when we create a new
+// search that overlaps with the existing search.
+func TestHistoricalNewTipOverlap(t *testing.T) {
+	tc := newHistTestCtx(t)
+	defer tc.cleanup()
+
+	// Instrument the mock chain so we can stop the search mid-way through.
+	tc.chain.sendNextCfilterChan = make(chan struct{})
+
+	// The generated test chain is:
+	// - 5 blocks that miss the cfilter match
+	// - 5 blocks with a cfilter match
+	// - block with test case manglers
+	// - 5 blocks with a cfilter match
+	// - block with second confirmed pkscript
+	tc.genBlocks(5, false)
+	tc.genBlocks(5, true)
+	b := tc.chain.newFromTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	tc.chain.extend(b)
+	tc.genBlocks(5, true)
+
+	// Start the search.
+	foundChan := make(chan Event)
+	tc.hist.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(foundChan),
+	)
+
+	// Let it process 3 blocks and start processing the fourth.
+	tc.chain.sendNextCfilterChan <- struct{}{}
+	tc.chain.sendNextCfilterChan <- struct{}{}
+	tc.chain.sendNextCfilterChan <- struct{}{}
+
+	// Let the blocks be processed.
+	time.Sleep(10 * time.Millisecond)
+
+	// Extend the tip with 3 new blocks, including a match of the target at
+	// the end.
+	startHeight := int32(13)
+	tc.genBlocks(2, true)
+	b2 := tc.chain.newFromTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	tc.chain.extend(b2)
+
+	// Start a new search which overlaps with the previous search. The
+	// start height will be lower than the previous search's end height and
+	// its current height.
+	foundChanNew := make(chan Event)
+	completeChanNew := make(chan struct{})
+	tc.hist.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(foundChanNew),
+		WithStartHeight(startHeight),
+		WithCompleteChan(completeChanNew),
+	)
+
+	// Send as many blocks as needed until no more are requested by the
+	// scan.
+	done := false
+	for !done {
+		select {
+		case tc.chain.sendNextCfilterChan <- struct{}{}:
+		case <-time.After(10 * time.Millisecond):
+			done = true
+		}
+	}
+
+	// Wait for the second scan to wrap up.
+	assertCompleted(tc.t, completeChanNew)
+
+	// We expect one (and only one) signal in each foundChan.
+	assertFoundChanRcvHeight(tc.t, foundChan, int32(b.block.Header.Height))
+	assertFoundChanRcvHeight(tc.t, foundChanNew, int32(b2.block.Header.Height))
+	assertFoundChanEmpty(tc.t, foundChan)
+	assertFoundChanEmpty(tc.t, foundChanNew)
+
+	// We only expect one fetch for each (cfilter matched) block.
+	wantGetBlockCount := uint32(14)
+	if tc.chain.getBlockCount != wantGetBlockCount {
+		t.Fatalf("Unexpected getBlockCount. want=%d got=%d",
+			wantGetBlockCount, tc.chain.getBlockCount)
+	}
+}
+
+// TestHistoricalAfterTip tests that attempting to scan past the current chain
+// tip works as expected.
+func TestHistoricalAfterTip(t *testing.T) {
+	tc := newHistTestCtx(t)
+	defer tc.cleanup()
+
+	// The generated test chain is:
+	// - 5 blocks that miss the cfilter match
+	// - 5 blocks with a cfilter match
+	// - block with test case manglers
+	// - 5 blocks with a cfilter match
+	// - block with second confirmed pkscript
+	tc.genBlocks(5, false)
+	tc.genBlocks(5, true)
+	b := tc.chain.newFromTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	tc.chain.extend(b)
+	tc.genBlocks(5, true)
+
+	completeChan := make(chan struct{})
+	foundChan := make(chan Event)
+
+	// Start the search with an EndHeight past the tip. The mock chain
+	// returns ErrBlockAfterTip in this situation.
+	tc.hist.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(foundChan),
+		WithCompleteChan(completeChan),
+		WithEndHeight(int32(tc.chain.tip.block.Header.Height)+1),
+	)
+
+	assertCompleted(t, completeChan)
+	assertFoundChanRcvHeight(t, foundChan, int32(b.block.Header.Height))
+}
+
+// BenchHistoricalCfilterMisses benchmarks the behavior of historical searches
+// when most/all blocks cause a cfilter check to miss (that is, full blocks
+// aren't downloaded and tested individually).
+//
+// Reported time and allocation count should be interpreted as per-block in the
+// blockchain.
+func BenchmarkHistoricalCfilterMisses(b *testing.B) {
+
+	runTC := func(c scannerTestCase, b *testing.B) {
+		b.ReportAllocs()
+		tc := newHistTestCtx(b)
+		defer tc.cleanup()
+
+		// Dummy block (will never match as we won't add it to the
+		// chain).
+		bl := tc.chain.newFromTip(c.manglers...)
+
+		// Generate N blocks without cfilter matches.
+		tc.genBlocks(b.N, false)
+		completeChan := make(chan struct{})
+		foundChan := make(chan Event)
+
+		targets := make([]TargetAndOptions, 1)
+		targets[0] = TargetAndOptions{
+			Target: c.target(bl),
+			Options: []Option{
+				WithCompleteChan(completeChan),
+				WithFoundChan(foundChan),
+			},
+		}
+
+		// Reset the benchmark to this point.
+		b.ResetTimer()
+
+		// Find all items and wait for them to complete.
+		tc.hist.FindMany(targets)
+		select {
+		case <-foundChan:
+			b.Fatal("Unexpected event in foundChan")
+		case <-completeChan:
+		case <-time.After(60 * time.Second):
+			b.Fatal("Timeout in benchmark")
+		}
+	}
+
+	// Test against all variants of targets.
+	for _, c := range scannerTestCases {
+		if !c.wantFound {
+			continue
+		}
+		c := c
+		ok := b.Run(c.name, func(b *testing.B) { runTC(c, b) })
+		if !ok {
+			break
+		}
+	}
+}
+
+// BenchHistoricalMatches benchmarks the behavior of historical searches when
+// most/all blocks cause a match in the block itself.
+//
+// Reported time and allocation counts should be interpreted as per-(1 input +
+// 1 output) in the blockchain.
+//
+// Note: This benchmark only runs for testcases which might match multiple
+// blocks (i.e., only match by script vs outpoint).
+func BenchmarkHistoricalMatches(b *testing.B) {
+
+	runTC := func(c scannerTestCase, b *testing.B) {
+		b.ReportAllocs()
+		tc := newHistTestCtx(b)
+		defer tc.cleanup()
+
+		bl := tc.chain.newFromTip(c.manglers...)
+
+		// Generate N blocks with block matches.
+		tc.chain.genBlocks(b.N, c.manglers...)
+		completeChan := make(chan struct{})
+		foundChan := make(chan Event)
+		var cbCount int
+		foundCb := func(_ Event, _ FindFunc) {
+			cbCount++
+		}
+
+		// Drain foundChan until completeChan is closed.
+		go func() {
+			for {
+				select {
+				case <-foundChan:
+				case <-completeChan:
+					return
+				}
+			}
+		}()
+
+		targets := make([]TargetAndOptions, 1)
+		targets[0] = TargetAndOptions{
+			Target: c.target(bl),
+			Options: []Option{
+				WithCompleteChan(completeChan),
+				WithFoundCallback(foundCb),
+				WithFoundChan(foundChan),
+			},
+		}
+
+		// Reset the benchmark to this point.
+		b.ResetTimer()
+
+		// Find all items and wait for them to complete.
+		tc.hist.FindMany(targets)
+		select {
+		case <-completeChan:
+			/*
+				if cbCount != b.N {
+					b.Fatalf("Different number of callback calls. want=%d got=%d",
+						b.N, cbCount)
+				}
+			*/
+		case <-time.After(60 * time.Second):
+			b.Fatal("Timeout in benchmark")
+		}
+	}
+
+	// Test against all variants of targets.
+	for _, c := range scannerTestCases {
+		// The only test cases amenable to this benchmark are those
+		// that use a fixed script or outpoint for matching.
+		//
+		// Returning multiple matches against a specific spent outpoint
+		// isn't really something that should happen in the blockchain
+		// but is useful as a benchmark method.
+		if c.name != "SpentScript" && c.name != "ConfirmedScript" && c.name != "SpentOutPoint" {
+			continue
+		}
+
+		c := c
+		ok := b.Run(c.name, func(b *testing.B) { runTC(c, b) })
+		if !ok {
+			break
+		}
+	}
+}
+
+// BenchHistorical benchmarks the behavior of historical searches when most/all
+// blocks cause a cfilter check to match (that is, full blocks are downloaded
+// and tested individually).
+//
+// Reported time and allocation should be interpreted as per-(1 input + 1
+// output) in the blockchain.
+func BenchmarkHistorical(b *testing.B) {
+
+	runTC := func(c scannerTestCase, b *testing.B) {
+		b.ReportAllocs()
+		tc := newHistTestCtx(b)
+		defer tc.cleanup()
+
+		// Dummy block (will never match as we won't add it to the
+		// chain).
+		bl := tc.chain.newFromTip(c.manglers...)
+
+		// Generate N blocks with cfilter matches.
+		tc.genBlocks(b.N, true)
+		completeChan := make(chan struct{})
+		foundChan := make(chan Event)
+
+		targets := make([]TargetAndOptions, 1)
+		targets[0] = TargetAndOptions{
+			Target: c.target(bl),
+			Options: []Option{
+				WithCompleteChan(completeChan),
+				WithFoundChan(foundChan),
+			},
+		}
+
+		// Reset the benchmark to this point.
+		b.ResetTimer()
+
+		// Find all items and wait for them to complete.
+		tc.hist.FindMany(targets)
+		select {
+		case <-foundChan:
+			b.Fatal("Unexpected event in foundChan")
+		case <-completeChan:
+		case <-time.After(60 * time.Second):
+			b.Fatal("Timeout in benchmark")
+		}
+	}
+
+	// Test against all variants of targets.
+	for _, c := range scannerTestCases {
+		if !c.wantFound {
+			continue
+		}
+		c := c
+		ok := b.Run(c.name, func(b *testing.B) { runTC(c, b) })
+		if !ok {
+			break
+		}
+	}
+}

--- a/chainscan/log.go
+++ b/chainscan/log.go
@@ -1,0 +1,28 @@
+package chainscan
+
+import (
+	"github.com/decred/dcrlnd/build"
+	"github.com/decred/slog"
+)
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log slog.Logger
+
+func init() {
+	UseLogger(build.NewSubLogger("CSCN", nil))
+}
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	UseLogger(slog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using slog.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/chainscan/multi_test.go
+++ b/chainscan/multi_test.go
@@ -1,0 +1,388 @@
+package chainscan
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/decred/dcrd/wire"
+)
+
+// scannerTestCase is a test case that must be fulfilled by both the historical
+// and the tip watcher individually.
+type scannerTestCase struct {
+	name      string
+	target    func(*testBlock) Target
+	manglers  []blockMangler
+	wantFound bool
+	wantMF    MatchField
+}
+
+var scannerTestCases = []scannerTestCase{
+
+	// Basic tests where a block should match the target.
+
+	{
+		name: "ConfirmedScript",
+		target: func(b *testBlock) Target {
+			return ConfirmedScript(0, testPkScript)
+		},
+		manglers: []blockMangler{
+			confirmScript(testPkScript),
+			cfilterData(testPkScript),
+		},
+		wantFound: true,
+		wantMF:    MatchTxOut,
+	},
+
+	{
+		name: "ConfirmedOutPoint",
+		target: func(b *testBlock) Target {
+			outp := wire.OutPoint{
+				Hash:  b.block.Transactions[0].TxHash(),
+				Index: 1,
+			}
+			return ConfirmedOutPoint(outp, 0, testPkScript)
+		},
+		manglers: []blockMangler{
+			confirmScript(testPkScript),
+			cfilterData(testPkScript),
+		},
+		wantFound: true,
+		wantMF:    MatchTxOut,
+	},
+
+	{
+		name: "SpentScript",
+		target: func(b *testBlock) Target {
+			return SpentScript(0, testPkScript)
+		},
+		manglers: []blockMangler{
+			spendScript(testSigScript),
+			cfilterData(testPkScript),
+		},
+		wantFound: true,
+		wantMF:    MatchTxIn,
+	},
+
+	{
+		name: "SpentOutPoint",
+		target: func(b *testBlock) Target {
+			outp := b.block.Transactions[0].TxIn[1].PreviousOutPoint
+			return SpentOutPoint(outp, 0, testPkScript)
+		},
+		manglers: []blockMangler{
+			spendOutPoint(testOutPoint),
+			cfilterData(testPkScript),
+		},
+		wantFound: true,
+		wantMF:    MatchTxIn,
+	},
+
+	// This test forces something that would ordinarily match in the block
+	// to not be included in the cfilter. This is not a realistic scenario
+	// in practice (due to consensus rules enforcing the correct behavior)
+	// but shows that if the cfilter doesn't match the block itself isn't
+	// tested.
+	{
+		name: "ConfirmedScript with cfilter miss",
+		target: func(b *testBlock) Target {
+			return ConfirmedScript(0, testPkScript)
+		},
+		manglers: []blockMangler{
+			confirmScript(testPkScript),
+		},
+	},
+
+	// The rest of the tests all force trigger a block check since a
+	// cfilter miss is trivial.
+
+	{
+		name: "ConfirmedScript without match",
+		target: func(b *testBlock) Target {
+			return ConfirmedScript(0, testPkScript)
+		},
+		manglers: []blockMangler{
+			// Note testPkScript is _not_ confirmed
+			cfilterData(testPkScript),
+		},
+	},
+
+	{
+		name: "ConfirmedOutPoint without match",
+		target: func(b *testBlock) Target {
+			outp := wire.OutPoint{
+				Hash:  b.block.Transactions[0].TxHash(),
+				Index: 1,
+			}
+			return ConfirmedOutPoint(outp, 0, testPkScript)
+		},
+		manglers: []blockMangler{
+			cfilterData(testPkScript),
+		},
+	},
+
+	// This tests that trying to watch for a specific outpoint fails when
+	// the script is confirmed in a _different_ outpoint.
+	{
+		name: "ConfirmedOutPoint with different outpoint",
+		target: func(b *testBlock) Target {
+			outp := wire.OutPoint{
+				Hash:  b.block.Transactions[0].TxHash(),
+				Index: 0,
+			}
+			return ConfirmedOutPoint(outp, 0, testPkScript)
+		},
+		manglers: []blockMangler{
+			confirmScript(testPkScript),
+			cfilterData(testPkScript),
+		},
+	},
+
+	{
+		name: "SpentScript without match",
+		target: func(b *testBlock) Target {
+			return SpentScript(0, testPkScript)
+		},
+		manglers: []blockMangler{
+			cfilterData(testPkScript),
+		},
+	},
+
+	{
+		name: "SpentOutPoint without match",
+		target: func(b *testBlock) Target {
+			outp := wire.OutPoint{
+				Hash:  b.block.Transactions[0].TxHash(),
+				Index: 1,
+			}
+			return SpentOutPoint(outp, 0, testPkScript)
+		},
+		manglers: []blockMangler{
+			cfilterData(testPkScript),
+		},
+	},
+
+	// This tests that a match is triggered even when the signatureScript
+	// of a watched outpoint does not correspond to the requested pkscript
+	// to watch for.
+	//
+	// Note that this is technically a client error given that watching for
+	// an outpoint when its correspondong pkscript is not the one specified
+	// in SpentOutpoint might cause the cfilter to never trigger a block
+	// download.
+	//
+	// Nevertheless we provide this test to fixate the TipWatcher's
+	// behavior in this situation.
+	{
+		name: "SpentOutPoint with different script",
+		target: func(b *testBlock) Target {
+			outp := b.block.Transactions[0].TxIn[1].PreviousOutPoint
+			return SpentOutPoint(outp, 0, testPkScript)
+		},
+		manglers: []blockMangler{
+			spendScript([]byte{0x00}),
+			cfilterData(testPkScript),
+		},
+		wantFound: true,
+		wantMF:    MatchTxIn,
+	},
+
+	// This asserts that a match is not triggered for a confirmation when
+	// the script is spent in a random input.
+	{
+		name: "ConfirmedScript with spent script",
+		target: func(b *testBlock) Target {
+			return ConfirmedScript(0, testPkScript)
+		},
+		manglers: []blockMangler{
+			spendScript(testSigScript),
+			cfilterData(testPkScript),
+		},
+	},
+
+	// The next tests all deal with transactions in the stake tree.
+
+	// This test asserts that spending an output which is in the stake tree
+	// gets detected.
+	{
+		name: "Spent Stake OutPoint",
+		target: func(b *testBlock) Target {
+			outp := b.block.Transactions[0].TxIn[1].PreviousOutPoint
+			return SpentOutPoint(outp, 0, testPkScript)
+		},
+		manglers: []blockMangler{
+			spendOutPoint(wire.OutPoint{
+				Hash: testOutPoint.Hash,
+				Tree: wire.TxTreeStake,
+			}),
+			cfilterData(testPkScript),
+		},
+		wantFound: true,
+		wantMF:    MatchTxIn,
+	},
+
+	{
+		name: "ConfirmedOutPoint in stake tx",
+		target: func(b *testBlock) Target {
+			outp := wire.OutPoint{
+				Hash:  b.block.STransactions[0].TxHash(),
+				Index: 1,
+				Tree:  wire.TxTreeStake,
+			}
+			return ConfirmedOutPoint(outp, 0, testPkScript)
+		},
+		manglers: []blockMangler{
+			confirmScript(testPkScript),
+			cfilterData(testPkScript),
+			moveRegularToStakeTree(),
+		},
+		wantFound: true,
+		wantMF:    MatchTxOut,
+	},
+
+	{
+		name: "ConfirmedScript in stake tx",
+		target: func(b *testBlock) Target {
+			return ConfirmedScript(0, testPkScript)
+		},
+		manglers: []blockMangler{
+			confirmScript(testPkScript),
+			cfilterData(testPkScript),
+			moveRegularToStakeTree(),
+		},
+		wantFound: true,
+		wantMF:    MatchTxOut,
+	},
+
+	// This test ensures that trying to watch for a script which should be
+	// confirmed in a specific output in the regular transaction tree fails
+	// to trigger a found event when that same script is actually confirmed
+	// in the stake tree.
+	{
+		name: "ConfirmedOutPoint in wrong tx tree",
+		target: func(b *testBlock) Target {
+			outp := wire.OutPoint{
+				Hash:  b.block.STransactions[0].TxHash(),
+				Index: 1,
+				Tree:  wire.TxTreeRegular,
+			}
+			return ConfirmedOutPoint(outp, 0, testPkScript)
+		},
+		manglers: []blockMangler{
+			confirmScript(testPkScript),
+			cfilterData(testPkScript),
+			moveRegularToStakeTree(),
+		},
+	},
+
+	{
+		name: "ConfirmedScript with large script",
+		target: func(b *testBlock) Target {
+			return ConfirmedScript(0, bytes.Repeat([]byte{0x55}, 128))
+		},
+		manglers: []blockMangler{
+			confirmScript(bytes.Repeat([]byte{0x55}, 128)),
+			cfilterData(bytes.Repeat([]byte{0x55}, 128)),
+		},
+		wantFound: true,
+		wantMF:    MatchTxOut,
+	},
+
+	{
+		name: "ConfirmedScript with large script without match",
+		target: func(b *testBlock) Target {
+			return ConfirmedScript(0, bytes.Repeat([]byte{0x55}, 128))
+		},
+		manglers: []blockMangler{
+			confirmScript(bytes.Repeat([]byte{0x55}, 127)),
+			cfilterData(bytes.Repeat([]byte{0x55}, 128)),
+		},
+	},
+}
+
+// TestSimultaneousScanners tests that when running both a TipWatcher and a
+// Historical rescan against the same chain, events are consistent with the
+// expected behavior of both scanners.
+func TestSimultaneousScanners(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chain := newMockChain()
+	chain.extend(chain.newFromTip()) // Genesis block
+
+	// The manglers that generate a block with a match.
+	confirmManglers := []blockMangler{
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	}
+
+	// The generated test chain is:
+	// - 5 blocks that miss the cfilter match
+	// - 5 blocks with a cfilter match
+	// - block which confirms the test pkscript
+	// - 5 blocks with a cfilter match
+	chain.genBlocks(5)
+	chain.genBlocks(5, cfilterData(testPkScript))
+	b := chain.newFromTip(confirmManglers...)
+	chain.extend(b)
+	chain.genBlocks(5, cfilterData(testPkScript))
+
+	// Create and run the scanners.
+	tw := NewTipWatcher(chain)
+	hist := NewHistorical(chain)
+	go func() {
+		tw.Run(ctx)
+	}()
+	go func() {
+		hist.Run(ctx)
+	}()
+
+	// Give it enough time for the TipWatcher to process the chain.
+	time.Sleep(10 * time.Millisecond)
+
+	// Attempt a search in both scanners in a consistent way. We first
+	// watch for the desired target in the tip watcher and use the returned
+	// starting watch height as the end of the historical search.
+	histFoundChan := make(chan Event)
+	tipFoundChan := make(chan Event)
+	swhChan := make(chan int32)
+
+	tw.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(tipFoundChan),
+		WithStartWatchHeightChan(swhChan),
+	)
+
+	endHeight := assertStartWatchHeightSignalled(t, swhChan)
+
+	// Generate a new block with the target script to simulate the tip
+	// changing between the call to TipWatcher.Find() and
+	// Historical.Find(). This could lead to multiple matches if the usage
+	// of the two scanners is inconsistent.
+	tip := chain.newFromTip(confirmManglers...)
+	chain.extend(tip)
+	chain.signalNewTip()
+
+	// The TipWatcher should trigger a match.
+	assertFoundChanRcvHeight(t, tipFoundChan, int32(tip.block.Header.Height))
+
+	// Run the historical scanner.
+	hist.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(histFoundChan),
+		WithEndHeight(endHeight),
+	)
+
+	// Generate a new tip confirming the test script.
+	tip = chain.newFromTip(confirmManglers...)
+	chain.extend(tip)
+	chain.signalNewTip()
+
+	// We expect to find one (and only one) signal in both chans, each
+	// pointing to their respective triggered event.
+	assertFoundChanRcvHeight(t, histFoundChan, int32(b.block.Header.Height))
+	assertFoundChanRcvHeight(t, tipFoundChan, int32(tip.block.Header.Height))
+	assertFoundChanEmpty(t, histFoundChan)
+	assertFoundChanEmpty(t, tipFoundChan)
+}

--- a/chainscan/notifier.go
+++ b/chainscan/notifier.go
@@ -1,0 +1,1 @@
+package chainscan

--- a/chainscan/pkscript.go
+++ b/chainscan/pkscript.go
@@ -1,7 +1,7 @@
 // Adapted from the upstream decred/dcrd file contained in the txscript
 // package.
 
-package chainntnfs
+package chainscan
 
 import (
 	"bytes"

--- a/chainscan/pkscript_test.go
+++ b/chainscan/pkscript_test.go
@@ -1,4 +1,4 @@
-package chainntnfs
+package chainscan
 
 import (
 	"bytes"

--- a/chainscan/pkscript_test.go
+++ b/chainscan/pkscript_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/decred/dcrd/chaincfg/v2"
 	"github.com/decred/dcrd/txscript/v3"
 )
 
@@ -257,13 +256,12 @@ func TestComputePkScript(t *testing.T) {
 	}
 
 	scriptVersion := uint16(0)
-	chainParams := chaincfg.RegNetParams()
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			valid := test.pkScript != nil
 			pkScript, err := ComputePkScript(
-				scriptVersion, test.sigScript, chainParams,
+				scriptVersion, test.sigScript,
 			)
 			if err != nil && valid {
 				t.Fatalf("unable to compute pkScript: %v", err)

--- a/chainscan/scanner.go
+++ b/chainscan/scanner.go
@@ -1,0 +1,829 @@
+package chainscan
+
+import (
+	"bytes"
+	"container/heap"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/gcs/v2"
+	"github.com/decred/dcrd/wire"
+	"github.com/decred/slog"
+)
+
+type MatchField uint8
+
+const (
+	MatchTxIn MatchField = 1 << iota
+	MatchTxOut
+)
+
+func (m MatchField) String() string {
+	switch m {
+	case MatchTxIn:
+		return "in"
+	case MatchTxOut:
+		return "out"
+	case MatchTxIn | MatchTxOut:
+		return "in|out"
+	default:
+		return "invalid"
+	}
+}
+
+var zeroOutPoint = wire.OutPoint{}
+
+type ChainSource interface {
+	GetBlock(context.Context, *chainhash.Hash) (*wire.MsgBlock, error)
+	CurrentTip(context.Context) (*chainhash.Hash, int32, error)
+}
+
+// ErrBlockAfterTip should be returned by chains when the requested block is
+// after the currently known tip. Scanners may choose not to fail their run if
+// this specific error is returned.
+type ErrBlockAfterTip struct {
+	Height int32
+}
+
+func (e ErrBlockAfterTip) Error() string {
+	return fmt.Sprintf("block %d is after currently known tip", e.Height)
+}
+
+func (e ErrBlockAfterTip) Is(err error) bool {
+	_, ok := err.(ErrBlockAfterTip)
+	return ok
+}
+
+type Event struct {
+	BlockHeight  int32
+	BlockHash    chainhash.Hash
+	TxIndex      int32
+	Tx           *wire.MsgTx
+	Index        int32
+	Tree         int8
+	MatchedField MatchField
+}
+
+func (e Event) String() string {
+	if (e.Tx) == nil {
+		return "unfilled event"
+	}
+
+	switch e.MatchedField {
+	case MatchTxOut:
+		return fmt.Sprintf("txOut=%s:%d height=%d",
+			e.Tx.CachedTxHash(), e.Index, e.BlockHeight)
+	case MatchTxIn:
+		return fmt.Sprintf("txIn=%s:%d height=%d",
+			e.Tx.CachedTxHash(), e.Index, e.BlockHeight)
+	default:
+		return "unknown matched field"
+	}
+}
+
+type FindFunc func(Target, ...Option) error
+type FoundCallback func(Event, FindFunc)
+
+// Target represents the desired target (outpoint, pkscript, etc) of a search.
+//
+// NOTE: targets are *not* safe for reuse for multiple searches.
+type Target interface {
+	// nop is meant to prevent external packages implementing this
+	// interface.
+	nop()
+}
+
+const (
+	flagMatchTxIn = 1 << iota
+	flagMatchTxOut
+	flagMatchOutpoint
+	flagMatchTxHash
+)
+
+type target struct {
+	// Fields that specify _what_ to match against
+
+	flags    int
+	out      wire.OutPoint
+	version  uint16
+	pkscript []byte
+
+	// Fields that control the _behavior_ during scans.
+
+	startHeight          int32
+	endHeight            int32
+	foundCb              FoundCallback
+	foundChan            chan<- Event
+	completeChan         chan struct{}
+	startWatchHeightChan chan int32
+	cancelChan           <-chan struct{}
+}
+
+func (c *target) String() string {
+	match := "unknown"
+	switch c.flags {
+	case flagMatchTxIn | flagMatchOutpoint:
+		match = "TxIn(outp)"
+	case flagMatchTxIn:
+		match = "TxIn(script)"
+	case flagMatchTxOut | flagMatchOutpoint:
+		match = "TxOut(outp)"
+	case flagMatchTxOut | flagMatchTxHash:
+		match = "TxOut(tx)"
+	case flagMatchTxOut:
+		match = "TxOut(script)"
+	}
+
+	return fmt.Sprintf("id=%p match=%s pkscript=%x out=%s", c, match,
+		c.pkscript, c.out)
+}
+
+func (c *target) canceled() bool {
+	select {
+	case <-c.cancelChan:
+		return true
+	default:
+		return false
+	}
+}
+
+// nop fulfills the Target interface.
+func (c *target) nop() {}
+
+// ConfirmedOutPoint tries to match against a TxOut that spends the provided
+// script but only as long as the output itself fulfills the specified outpoint
+// (that is, the output is created in the transaction specified by out.Hash and
+// at the out.Index position).
+func ConfirmedOutPoint(out wire.OutPoint, version uint16, pkscript []byte) Target {
+	return &target{
+		flags:    flagMatchTxOut | flagMatchOutpoint,
+		out:      out,
+		version:  version,
+		pkscript: pkscript,
+	}
+}
+
+func ConfirmedTransaction(txh chainhash.Hash, version uint16, pkscript []byte) Target {
+	return &target{
+		flags: flagMatchTxOut | flagMatchTxHash,
+		out: wire.OutPoint{
+			Hash: txh,
+		},
+		version:  version,
+		pkscript: pkscript,
+	}
+}
+
+func ConfirmedScript(version uint16, pkscript []byte) Target {
+	return &target{
+		flags:    flagMatchTxOut,
+		version:  version,
+		pkscript: pkscript,
+	}
+}
+
+// SpentScript tries to match against a TxIn that spends the provided script.
+//
+// NOTE: only version 0 scripts are currently supported. Also, the match is a
+// best effort one, based on the "shape" of the signature script of the txin.
+// See ComputePkScript for details on supported script types.
+func SpentScript(version uint16, pkscript []byte) Target {
+	return &target{
+		flags:    flagMatchTxIn,
+		version:  version,
+		pkscript: pkscript,
+	}
+}
+
+// SpentOutPoint tries to match against a TxIn that spends the given outpoint
+// and pkscript combination.
+//
+// NOTE: If the provided pkscript does _not_ actually correspond to the
+// outpoint, the search may never trigger a match.
+func SpentOutPoint(out wire.OutPoint, version uint16, pkscript []byte) Target {
+	return &target{
+		flags:    flagMatchTxIn | flagMatchOutpoint,
+		out:      out,
+		version:  version,
+		pkscript: pkscript,
+	}
+}
+
+type Option func(*target)
+
+// WithStartHeight allows a caller to specify a block height after which a scan
+// should trigger events when this target is found.
+func WithStartHeight(startHeight int32) Option {
+	return func(t *target) {
+		t.startHeight = startHeight
+	}
+}
+
+// WithEndHeight allows a caller to specify a block height after which scans
+// should no longer happen.
+func WithEndHeight(endHeight int32) Option {
+	return func(t *target) {
+		t.endHeight = endHeight
+	}
+}
+
+// WithFoundCallback allows a caller to specify a callback that is called
+// synchronously in relation to a scanner when the related target is found in a
+// block.
+//
+// This callback is called in the same goroutine that performs scans, therefore
+// it is *NOT* safe to perform any receives or sends on channels that also
+// affect this or other target's searches (such as waiting for a
+// StartWatchingHeight, FoundChan or other signals).
+//
+// It is also generally not advised to perform lengthy operations inside this
+// callback since it blocks all other searches from progressing.
+//
+// This callback is intended to be used in situations where the caller needs to
+// add new targets to search for as a result of having found a match within a
+// block.
+//
+// There are two ways to add addicional targets during the execution of the
+// foundCallback:
+//
+//   1. Via additional Find() calls of the scanner (which _are_ safe for direct
+//   calling by the foundCallback). This allows callers to start to search for
+//   additional targets on the _next_ block checked by the scanner.
+//
+//   2. Via the second argument to the foundCallback. That function can add
+//   targets to search for, starting at the _current_ block, transaction list
+//   and transaction index. This is useful (for example) when detecting a
+//   specific script was used in an output should trigger a search for other
+//   scripts including in the same block.
+//
+// The callback function may be called multiple times for a given target.
+func WithFoundCallback(cb FoundCallback) Option {
+	return func(t *target) {
+		t.foundCb = cb
+	}
+}
+
+// WithFoundChan allows a caller to specify a channel that receives events when
+// a match for a given target is found. This event is called concurrently with
+// the rest of the search process.
+//
+// Callers are responsible for draining this channel once the search completes,
+// otherwise data may leak. They should also ensure the channel is _not_ closed
+// until the search completes, otherwise the scanner may panic.
+//
+// The channel may be sent to multiple times.
+func WithFoundChan(c chan<- Event) Option {
+	return func(t *target) {
+		t.foundChan = c
+	}
+}
+
+// WithCompleteChan allows a caller to specify a channel that gets closed once
+// the endHeight was reached for the target.
+func WithCompleteChan(c chan struct{}) Option {
+	return func(t *target) {
+		t.completeChan = c
+	}
+}
+
+// WithCancelChan allows a caller to specify a channel that, once closed,
+// removes the provided target from being scanned for.
+func WithCancelChan(c <-chan struct{}) Option {
+	return func(t *target) {
+		t.cancelChan = c
+	}
+}
+
+// WithStartWatchHeightChan allows a caller to specify a channel that receives
+// the block height after which events will be triggered if the target is
+// found.
+func WithStartWatchHeightChan(c chan int32) Option {
+	return func(t *target) {
+		t.startWatchHeightChan = c
+	}
+}
+
+type TargetAndOptions struct {
+	Target  Target
+	Options []Option
+}
+
+const txOutKeyLen = 32
+
+type txOutKey [txOutKeyLen]byte
+
+func newTxOutKey(version uint16, pkscript []byte) txOutKey {
+	// key := make([]byte, 2+len(pkscript))
+	var key txOutKey
+	key[0] = byte(version >> 8)
+	key[1] = byte(version)
+	copy(key[2:], pkscript)
+	return key
+
+}
+
+// targetSlice is a slice of targets that can be modified in-place by adding
+// and removing items via the add and del functions.
+//
+// This is used to simplify the code of some operations in scanners (vs using
+// regular slices).
+type targetSlice []*target
+
+func (ts *targetSlice) del(t *target) {
+	s := *ts
+	for i := 0; i < len(s); i++ {
+		if s[i] == t {
+			s[i] = s[len(s)-1]
+			s[len(s)-1] = nil
+			*ts = s[:len(s)-1]
+			return
+		}
+	}
+}
+
+func (ts *targetSlice) add(t *target) {
+	s := *ts
+	*ts = append(s, t)
+}
+
+func (ts *targetSlice) empty() bool {
+	return len(*ts) == 0
+}
+
+// targetHeap is a sortable slice of targets that fulfills the heap.Interface
+// interface by sorting in ascending order of start height.
+type targetHeap []*target
+
+func (th targetHeap) Len() int           { return len(th) }
+func (th targetHeap) Less(i, j int) bool { return th[i].startHeight < th[j].startHeight }
+func (th targetHeap) Swap(i, j int)      { th[i], th[j] = th[j], th[i] }
+
+func (th *targetHeap) Push(x interface{}) {
+	*th = append(*th, x.(*target))
+}
+
+func (th *targetHeap) Pop() interface{} {
+	old := *th
+	n := len(old)
+	x := old[n-1]
+	old[n-1] = nil // Avoid leaking the target.
+	*th = old[0 : n-1]
+	return x
+}
+
+func (th *targetHeap) push(ts ...*target) {
+	for _, t := range ts {
+		heap.Push(th, t)
+	}
+}
+
+func (th *targetHeap) pop() *target {
+	return heap.Pop(th).(*target)
+}
+
+func (th *targetHeap) peak() *target {
+	if len(*th) > 0 {
+		return (*th)[0]
+	}
+	return nil
+}
+
+// asTargetHeap returns the slice of targets as a targetHeap. The order of
+// elements of the backing array of the given slice may be modified by this
+// fuction.
+func asTargetHeap(targets []*target) *targetHeap {
+	th := targetHeap(targets)
+	heap.Init(&th)
+	return &th
+}
+
+var _ heap.Interface = (*targetHeap)(nil)
+
+// targetList is a list of targets which can be queried for matches against
+// blocks.
+//
+// It maintains several caches so that queries for the multiple targets in a
+// block can be done only in linear time (on the number of inputs+outputs of
+// the transactions).
+//
+// targetList values aren't safe for concurrent access from multiple
+// goroutines.
+type targetList struct {
+	targets        map[*target]struct{}
+	cfEntries      [][]byte
+	dirty          bool
+	txInKeys       map[wire.OutPoint]*targetSlice
+	txInScriptKeys map[txOutKey]*targetSlice
+	txOutKeys      map[txOutKey]*targetSlice
+
+	// blockHeight is the current height being processed during a call for
+	// singalFound().
+	blockHeight int32
+
+	// ff stores a reference to the the target list's addDuringFoundCb
+	// function. Storing as a field here avoids having to perform an
+	// allocation during the critical code path when matches occur in a
+	// block.
+	ff FindFunc
+}
+
+func newTargetList(initial []*target) *targetList {
+	tl := &targetList{
+		targets:        make(map[*target]struct{}, len(initial)),
+		txInKeys:       make(map[wire.OutPoint]*targetSlice, len(initial)),
+		txInScriptKeys: make(map[txOutKey]*targetSlice, len(initial)),
+		txOutKeys:      make(map[txOutKey]*targetSlice, len(initial)),
+	}
+
+	for _, t := range initial {
+		tl.add(t)
+	}
+	tl.rebuildCfilterEntries()
+
+	tl.ff = FindFunc(tl.addDuringFoundCb)
+
+	return tl
+}
+
+func (tl *targetList) empty() bool {
+	return len(tl.targets) == 0
+}
+
+func (tl *targetList) add(newTargets ...*target) {
+	for _, nt := range newTargets {
+		if _, ok := tl.targets[nt]; ok {
+			continue
+		}
+
+		tl.targets[nt] = struct{}{}
+		if nt.flags&flagMatchTxIn == flagMatchTxIn {
+			if nt.flags&flagMatchOutpoint == 0 {
+				// Match by input script.
+				key := newTxOutKey(nt.version, nt.pkscript)
+				if _, ok := tl.txInScriptKeys[key]; !ok {
+					tl.txInScriptKeys[key] = &targetSlice{}
+				}
+				tl.txInScriptKeys[key].add(nt)
+			} else {
+				// Match by outpoint.
+				outp := nt.out
+				if _, ok := tl.txInKeys[outp]; !ok {
+					tl.txInKeys[outp] = &targetSlice{}
+				}
+				tl.txInKeys[outp].add(nt)
+			}
+		}
+
+		if nt.flags&flagMatchTxOut == flagMatchTxOut {
+			key := newTxOutKey(nt.version, nt.pkscript)
+			if _, ok := tl.txOutKeys[key]; !ok {
+				tl.txOutKeys[key] = &targetSlice{}
+			}
+			tl.txOutKeys[key].add(nt)
+		}
+	}
+
+	tl.dirty = true
+}
+
+func (tl *targetList) removeAll() []*target {
+	targets := make([]*target, len(tl.targets))
+	var i int
+	for t := range tl.targets {
+		targets[i] = t
+	}
+	tl.remove(targets...)
+	return targets
+}
+
+func (tl *targetList) remove(newTargets ...*target) {
+	for _, nt := range newTargets {
+		if _, ok := tl.targets[nt]; !ok {
+			continue
+		}
+
+		tl.dirty = true
+
+		if nt.flags&flagMatchTxIn == flagMatchTxIn {
+			if nt.out == zeroOutPoint {
+				key := newTxOutKey(nt.version, nt.pkscript)
+				if _, ok := tl.txInScriptKeys[key]; ok {
+					tl.txInScriptKeys[key].del(nt)
+					if tl.txInScriptKeys[key].empty() {
+						delete(tl.txInScriptKeys, key)
+					}
+				}
+			} else {
+				outp := nt.out
+				if _, ok := tl.txInKeys[outp]; ok {
+					tl.txInKeys[outp].del(nt)
+					if tl.txInKeys[outp].empty() {
+						delete(tl.txInKeys, outp)
+					}
+				}
+			}
+		}
+
+		if nt.flags&flagMatchTxOut == flagMatchTxOut {
+			key := newTxOutKey(nt.version, nt.pkscript)
+			if _, ok := tl.txOutKeys[key]; ok {
+				tl.txOutKeys[key].del(nt)
+				if tl.txOutKeys[key].empty() {
+					delete(tl.txOutKeys, key)
+				}
+			}
+		}
+
+		delete(tl.targets, nt)
+	}
+}
+
+// removeStale removes all targets that have been canceled or for which their
+// endHeight was reached as specified by the 'height' parameter. This function
+// returns only the targets for which the endHeight was reached.
+func (tl *targetList) removeStale(height int32) []*target {
+	var stale []*target
+	for t := range tl.targets {
+		del := false
+		if height >= t.endHeight {
+			// Got to the end of the watching interval for the
+			// given target.
+			stale = append(stale, t)
+			del = true
+			log.Tracef("Removing stale target at %d: %s", height, t)
+		}
+
+		select {
+		case <-t.cancelChan:
+			del = true
+			log.Tracef("Removing canceled target at %d: %s", height, t)
+		default:
+		}
+
+		if del {
+			tl.remove(t)
+		}
+	}
+
+	return stale
+}
+
+func (tl *targetList) rebuildCfilterEntries() {
+	cf := make([][]byte, 0, len(tl.targets))
+	for t := range tl.targets {
+		cf = append(cf, t.pkscript)
+	}
+	tl.cfEntries = cf
+	tl.dirty = false
+}
+
+func (tl *targetList) addDuringFoundCb(tgt Target, opts ...Option) error {
+	t, ok := tgt.(*target)
+	if !ok {
+		return errors.New("provided target should be chainscan.*target")
+	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	if t.endHeight > 0 && t.endHeight < tl.blockHeight {
+		return errors.New("cannot add targets during foundCb with " +
+			"endHeight lower than the current blockHeight")
+	}
+
+	if t.startHeight != 0 && t.startHeight != tl.blockHeight {
+		return errors.New("cannot add targets during foundCb with " +
+			"startHeight different than the current blockHeight")
+	}
+
+	tl.add(t)
+	return nil
+}
+
+// signalMatches finds and signals all matches of the current target list in
+// the given block.
+func (tl *targetList) signalFound(blockHeight int32, blockHash *chainhash.Hash, block *wire.MsgBlock) {
+	// Filled after the first match on a transaction is found.
+	var txid chainhash.Hash
+	var ptxid *chainhash.Hash
+
+	var event Event
+
+	tl.blockHeight = blockHeight
+
+	// Whether there are any inputs that will be matched by script only
+	// instead of by outpoint.
+	matchByInScript := len(tl.txInScriptKeys) > 0
+
+	// Flag to test against so we verify a match against a specific output
+	// of a confirmed output.
+	flagTxOutWithOutp := flagMatchTxOut | flagMatchOutpoint
+
+	// Fill events for all targets from ts that have matched against the
+	// transaction tx at field f and index i.
+	fillMatches := func(ts []*target, tx *wire.MsgTx, tree int8, i int32, f MatchField, txi int32) {
+		// "large" scripts are those that surpass the the maximum key
+		// length size for output matching. In that case, we also need
+		// to check the full script on targets.
+		//
+		// This should be a rare occurrence given the absolute majority
+		// of scripts are P2PKH and P2SH.
+		//
+		// Scripts in inputs don't need this check because
+		// ComputePkScript only supports P2PKH and P2SH.
+		largeScript := f == MatchTxOut && len(tx.TxOut[i].PkScript) > txOutKeyLen
+
+		for _, t := range ts {
+			// Canceled targets can't be triggered.
+			if t.canceled() {
+				continue
+			}
+
+			// Large scripts that don't match aren't signalled.
+			if largeScript && !bytes.Equal(t.pkscript, tx.TxOut[i].PkScript) {
+				continue
+			}
+
+			if t.flags&flagTxOutWithOutp == flagTxOutWithOutp {
+				// When matching against TxOut's, if the
+				// outpoint in the target is specified we only
+				// match against that specific output. So we
+				// need to calculate the txid and verify the
+				// target's outpoint with the txid+index.
+				//
+				// We check the index and tree first since
+				// there's no point in calculating the txid if
+				// the other fields don't match.
+				if i != int32(t.out.Index) || tree != t.out.Tree {
+					continue
+				}
+
+				// Calculate tx hash if needed.
+				if ptxid == nil {
+					txid = tx.TxHash()
+					ptxid = &txid
+				}
+
+				if txid != t.out.Hash {
+					continue
+				}
+			}
+
+			// Match against only the tx hash.
+			if t.flags&flagMatchTxHash == flagMatchTxHash {
+				// Calculate tx hash if needed.
+				if ptxid == nil {
+					txid = tx.TxHash()
+					ptxid = &txid
+				}
+
+				if txid != t.out.Hash {
+					continue
+				}
+			}
+
+			// Found a match!
+			event = Event{
+				BlockHeight:  blockHeight,
+				BlockHash:    *blockHash,
+				TxIndex:      txi,
+				Tx:           tx,
+				Index:        i,
+				Tree:         tree,
+				MatchedField: f,
+			}
+
+			if log.Level() <= slog.LevelDebug {
+				log.Debugf("Matched %s for target %s", event, t)
+			}
+
+			if t.foundCb != nil {
+				// foundCb() is called synchronously so that it
+				// can modify scanners before the scan
+				// continues.
+				t.foundCb(event, tl.ff)
+				matchByInScript = len(tl.txInScriptKeys) > 0
+			}
+			if t.foundChan != nil {
+				// foundChan is signalled asynchronously so
+				// scans aren't blocked.
+				go func(c chan<- Event, e Event) {
+					c <- e
+				}(t.foundChan, event)
+			}
+		}
+	}
+
+	// Process both the regular and stake transaction trees.
+	trees := []int8{wire.TxTreeRegular, wire.TxTreeStake}
+	var txs []*wire.MsgTx
+
+	for _, tree := range trees {
+		switch tree {
+		case wire.TxTreeStake:
+			txs = block.STransactions
+		default:
+			txs = block.Transactions
+		}
+
+		for txi, tx := range txs {
+			ptxid = nil
+			for i, in := range tx.TxIn {
+				if ts, ok := tl.txInKeys[in.PreviousOutPoint]; ok {
+					fillMatches(*ts, tx, tree, int32(i), MatchTxIn, int32(txi))
+				}
+
+				// Only continue to process the input if we
+				// need to match by input script.
+				if !matchByInScript {
+					continue
+				}
+
+				script, err := ComputePkScript(0, in.SignatureScript)
+				if err != nil {
+					// If this is an unrecognized script
+					// type it can't possibly be a match.
+					continue
+				}
+
+				// Guessing it's a version 0 script. How to
+				// support other types?
+				key := newTxOutKey(0, script.Script())
+				if ts, ok := tl.txInScriptKeys[key]; ok {
+					fillMatches(*ts, tx, tree, int32(i), MatchTxIn, int32(txi))
+				}
+			}
+
+			for i, out := range tx.TxOut {
+				key := newTxOutKey(out.Version, out.PkScript)
+				if ts, ok := tl.txOutKeys[key]; ok {
+					fillMatches(*ts, tx, tree, int32(i), MatchTxOut, int32(txi))
+				}
+			}
+		}
+	}
+}
+
+// signalComplete closes the completeChan of all targets in the specified
+// slice.
+func signalComplete(targets []*target) {
+	for _, t := range targets {
+		if t.completeChan != nil {
+			close(t.completeChan)
+		}
+	}
+}
+
+// signalStartWatchHeight sends the given height as the start watching height
+// for all applicable targets in the slice.
+func signalStartWatchHeight(targets []*target, height int32) {
+	for _, t := range targets {
+		if t.startWatchHeightChan != nil {
+			go func(c chan int32) {
+				c <- height
+			}(t.startWatchHeightChan)
+		}
+	}
+}
+
+// blockCFilter is an auxillary structure used to hold all data required to
+// query a v2 cfilter of a given block.
+type blockCFilter struct {
+	hash       *chainhash.Hash
+	height     int32
+	cfilterKey [16]byte
+	cfilter    *gcs.FilterV2
+}
+
+func (bcf blockCFilter) matches(entries [][]byte) bool {
+	return bcf.cfilter.MatchAny(bcf.cfilterKey, entries)
+}
+
+// scan performs a cfilter and then (if needed) a full block scan in the given
+// blockcf for the specified target list.
+//
+// getBlock must be able to fetch the specified full block data.
+//
+// Note that the `targets` target list may have been modified by this call,
+// therefore callers should check whether the target list is dirty and rebuild
+// cfilter entries as appropriate.
+func scan(ctx context.Context, blockcf *blockCFilter, targets *targetList, getBlock func(context.Context, *chainhash.Hash) (*wire.MsgBlock, error)) error {
+	if !blockcf.matches(targets.cfEntries) {
+		return nil
+	}
+
+	// Find and process matches in the actual block, given the cfilter test
+	// passed.
+	block, err := getBlock(ctx, blockcf.hash)
+	if err != nil {
+		return err
+	}
+
+	// Alert clients of matches found.
+	targets.signalFound(blockcf.height, blockcf.hash, block)
+
+	return nil
+}

--- a/chainscan/scanner_test.go
+++ b/chainscan/scanner_test.go
@@ -1,0 +1,52 @@
+package chainscan
+
+import (
+	"testing"
+)
+
+// TestTargetSlice tests whether the targetSlice struct behaves correctly.
+func TestTargetSlice(t *testing.T) {
+
+	t1 := &target{version: 1}
+	t2 := &target{version: 2}
+	t3 := &target{version: 3}
+
+	ts := &targetSlice{}
+
+	assertContains := func(want []*target) {
+		t.Helper()
+		got := *ts
+		if len(want) != len(got) {
+			t.Fatalf("different slice lengths; want=%v got=%v", want, got)
+		}
+
+		for i := range want {
+			found := false
+			for j := range got {
+				if want[i] == got[j] {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("could not find wanted element %d. "+
+					"want=%v got=%v", i, want, got)
+			}
+
+		}
+	}
+
+	ts.add(t1)
+	ts.add(t2)
+	ts.add(t3)
+	assertContains([]*target{t1, t2, t3})
+
+	ts.del(t2)
+	assertContains([]*target{t1, t3})
+
+	ts.del(t1)
+	assertContains([]*target{t3})
+
+	ts.del(t3)
+	assertContains([]*target{})
+}

--- a/chainscan/tip.go
+++ b/chainscan/tip.go
@@ -1,0 +1,296 @@
+package chainscan
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/gcs/v2"
+)
+
+type ChainEvent interface {
+	BlockHash() *chainhash.Hash
+	BlockHeight() int32
+	PrevBlockHash() *chainhash.Hash
+
+	nop()
+}
+
+type BlockConnectedEvent struct {
+	Hash     chainhash.Hash
+	Height   int32
+	PrevHash chainhash.Hash
+	CFKey    [16]byte
+	Filter   *gcs.FilterV2
+}
+
+func (e BlockConnectedEvent) BlockHash() *chainhash.Hash     { return &e.Hash }
+func (e BlockConnectedEvent) BlockHeight() int32             { return e.Height }
+func (e BlockConnectedEvent) PrevBlockHash() *chainhash.Hash { return &e.PrevHash }
+func (e BlockConnectedEvent) nop()                           {}
+func (e BlockConnectedEvent) blockCF() *blockCFilter {
+	return &blockCFilter{
+		hash:       &e.Hash,
+		height:     e.Height,
+		cfilterKey: e.CFKey,
+		cfilter:    e.Filter,
+	}
+}
+
+type BlockDisconnectedEvent struct {
+	Hash     chainhash.Hash
+	Height   int32
+	PrevHash chainhash.Hash
+}
+
+func (e BlockDisconnectedEvent) BlockHash() *chainhash.Hash     { return &e.Hash }
+func (e BlockDisconnectedEvent) BlockHeight() int32             { return e.Height }
+func (e BlockDisconnectedEvent) PrevBlockHash() *chainhash.Hash { return &e.PrevHash }
+func (e BlockDisconnectedEvent) nop()                           {}
+
+// TipChainSource defines the required backend functions for the TipWatcher
+// scanner to perform its duties.
+type TipChainSource interface {
+	ChainSource
+
+	// ChainEvents MUST return a channel that is sent ChainEvent's until
+	// the passed context is canceled.
+	ChainEvents(context.Context) <-chan ChainEvent
+}
+
+type eventReader struct {
+	ctx context.Context
+	c   chan ChainEvent
+}
+
+type forcedRescan struct {
+	e    BlockConnectedEvent
+	done chan error
+}
+
+type TipWatcher struct {
+	ctx     context.Context
+	running int32 // CAS 1=already running
+
+	newTargetsChan chan []*target
+
+	chain TipChainSource
+
+	mtx          sync.Mutex
+	eventReaders []*eventReader
+
+	forcedRescanChan chan forcedRescan
+
+	// The following fields are only used during testing.
+
+	// If specified, after processing a new tip it will be signalled with
+	// the new tip.
+	tipProcessed chan *blockCFilter
+
+	// If specified, Find() blocks until the target has been received by
+	// the Run() goroutine.
+	syncFind bool
+}
+
+func NewTipWatcher(chain TipChainSource) *TipWatcher {
+	return &TipWatcher{
+		chain:            chain,
+		newTargetsChan:   make(chan []*target),
+		forcedRescanChan: make(chan forcedRescan),
+	}
+}
+
+// ChainEvents follows the same semantics as the TipChainSource ChainEvents but
+// ensures all channels are only signalled _after_ the tip watcher has
+// processed them.
+func (tw *TipWatcher) ChainEvents(ctx context.Context) <-chan ChainEvent {
+	r := &eventReader{
+		ctx: ctx,
+		c:   make(chan ChainEvent),
+	}
+	tw.mtx.Lock()
+	tw.eventReaders = append(tw.eventReaders, r)
+	tw.mtx.Unlock()
+	return r.c
+}
+
+func (tw *TipWatcher) signalEventReaders(e ChainEvent) {
+	tw.mtx.Lock()
+	readers := tw.eventReaders
+	tw.mtx.Unlock()
+
+	for _, er := range readers {
+		select {
+		case <-er.ctx.Done():
+		case er.c <- e:
+		}
+	}
+}
+
+// targetsForTipWatching splits a list of targets into three sublists assuming
+// the current tip height of 'height':
+//
+//   - List of new targets that need to be watched.
+//   - List of waiting targets which have not yet reached their watching height.
+//   - List of stale targets for which their end height was reached.
+func targetsForTipWatching(height int32, targets []*target) ([]*target, []*target, []*target) {
+	var newTargets, staleTargets, waitingTargets []*target
+
+	for _, t := range targets {
+		switch {
+		// A canceled target can't be watched for.
+		case t.canceled():
+			log.Tracef("Canceled target for tip watching: %s", t)
+
+		// endHeight for watching this target already passed, so this
+		// is actually a stale target.
+		case t.endHeight != 0 && t.endHeight <= height:
+			staleTargets = append(staleTargets, t)
+			log.Tracef("Stale target for tip watching: %s", t)
+
+		// New target to be watched.
+		case t.startHeight <= height:
+			newTargets = append(newTargets, t)
+			log.Tracef("New target for tip watching: %s", t)
+
+		// Haven't reached the height to start watching this target
+		// yet.
+		default:
+			waitingTargets = append(waitingTargets, t)
+			log.Tracef("Waiting target tip for watching: %s", t)
+		}
+	}
+
+	return newTargets, staleTargets, waitingTargets
+}
+
+func (tw *TipWatcher) Run(ctx context.Context) error {
+	if !atomic.CompareAndSwapInt32(&tw.running, 0, 1) {
+		return errors.New("already running")
+	}
+
+	tw.ctx = ctx
+	defer func() {
+		tw.ctx = nil
+		atomic.StoreInt32(&tw.running, 0)
+	}()
+
+	_, tipHeight, err := tw.chain.CurrentTip(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Setup the chan that receives chain events.
+	ceCtx, cancelCe := context.WithCancel(context.Background())
+	defer cancelCe()
+	chainEvents := tw.chain.ChainEvents(ceCtx)
+
+	var waitingTargets []*target
+	targets := newTargetList(nil)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case newTargets := <-tw.newTargetsChan:
+			waitingTargets = append(waitingTargets, newTargets...)
+
+		case fr := <-tw.forcedRescanChan:
+			log.Debugf("Forcing rescan of (height=%d hash=%s)",
+				fr.e.Height, fr.e.Hash)
+
+			// We ignore errors here because we may have been
+			// provided a wrong block hash (for example). A
+			// canceled tw.ctx will be looked for in the next
+			// iteration of the loop.
+			fr.done <- scan(tw.ctx, fr.e.blockCF(), targets, tw.chain.GetBlock)
+
+		case ce := <-chainEvents:
+			// Ignore block disconnections.
+			e, ok := ce.(BlockConnectedEvent)
+			if !ok {
+				log.Tracef("TipWatcher ignoring disconnect (height=%d hash=%s)",
+					ce.BlockHeight(), ce.BlockHash())
+				tw.signalEventReaders(ce)
+				continue
+			}
+
+			log.Debugf("TipWatcher next tip received (height=%d hash=%s)",
+				e.Height, e.Hash)
+			err := scan(tw.ctx, e.blockCF(), targets, tw.chain.GetBlock)
+			if err != nil {
+				return err
+			}
+			tipHeight = e.Height
+
+			stale := targets.removeStale(tipHeight)
+			signalComplete(stale)
+
+			tw.signalEventReaders(ce)
+			if tw.tipProcessed != nil {
+				tw.tipProcessed <- e.blockCF()
+			}
+		}
+
+		// Update the list of watched targets with any new ones or ones
+		// that might have been waiting for the startHeight to be
+		// reached.
+		brandNew, waiting, stale := targetsForTipWatching(tipHeight, waitingTargets)
+		signalComplete(stale)
+		waitingTargets = waiting
+		targets.add(brandNew...)
+		signalStartWatchHeight(brandNew, tipHeight)
+
+		if targets.dirty {
+			targets.rebuildCfilterEntries()
+		}
+	}
+}
+
+func (tw *TipWatcher) ForceRescan(ctx context.Context, e *BlockConnectedEvent) error {
+	fr := forcedRescan{
+		e:    *e,
+		done: make(chan error),
+	}
+	select {
+	case tw.forcedRescanChan <- fr:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	return <-fr.done
+}
+
+func (tw *TipWatcher) Find(tgt Target, opts ...Option) error {
+	t, ok := tgt.(*target)
+	if !ok {
+		return errors.New("provided target should be chainscan.*target")
+	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	switch {
+	case t.endHeight < 0:
+		return errors.New("cannot tip watch with endHeight < 0")
+	case t.endHeight == 0:
+		// Maximum endHeight so the target never goes stale.
+		t.endHeight = 1<<31 - 1
+	}
+
+	// syncFind should only be specified during tests since it risks
+	// deadlocking the tipWatcher.
+	if tw.syncFind {
+		tw.newTargetsChan <- []*target{t}
+		return nil
+	}
+
+	go func() {
+		tw.newTargetsChan <- []*target{t}
+	}()
+
+	return nil
+}

--- a/chainscan/tip_test.go
+++ b/chainscan/tip_test.go
@@ -1,0 +1,635 @@
+package chainscan
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/decred/dcrd/wire"
+)
+
+type twTestCtx struct {
+	chain  *mockChain
+	tw     *TipWatcher
+	cancel func()
+	t      *testing.T
+}
+
+func newTwTestCtx(t *testing.T) *twTestCtx {
+	ctx, cancel := context.WithCancel(context.Background())
+	chain := newMockChain()
+	tw := NewTipWatcher(chain)
+	chain.extend(chain.newFromTip()) // Genesis block
+
+	// Instrument tipProcessed.
+	tw.tipProcessed = make(chan *blockCFilter)
+
+	// Use synchronous version of Find() for tests by default.
+	tw.syncFind = true
+
+	go func() {
+		tw.Run(ctx)
+	}()
+	return &twTestCtx{
+		chain:  chain,
+		tw:     tw,
+		cancel: cancel,
+		t:      t,
+	}
+}
+
+func (t *twTestCtx) cleanup() {
+	t.cancel()
+}
+
+func (t *twTestCtx) extendTipWait(b *testBlock) {
+	t.t.Helper()
+	t.chain.extend(b)
+	t.chain.signalNewTip()
+	select {
+	case <-t.tw.tipProcessed:
+	case <-time.After(5 * time.Second):
+		t.t.Fatal("new tip not processed in time")
+	}
+}
+
+func (t *twTestCtx) extendNewTip(manglers ...blockMangler) *testBlock {
+	t.t.Helper()
+	b := t.chain.newFromTip(manglers...)
+	t.extendTipWait(b)
+	return b
+}
+
+// TestTipWatcher tests the basic functionality of the TipWatcher by testing it
+// against the scannerTestCases which must be fulfilled by both the tipWatcher
+// and historical scanners.
+func TestTipWatcher(t *testing.T) {
+	runTC := func(c scannerTestCase, t *testing.T) {
+		var foundCbEvent, foundChanEvent Event
+		foundChan := make(chan Event)
+		tc := newTwTestCtx(t)
+		defer tc.cleanup()
+
+		b := tc.chain.newFromTip(c.manglers...)
+		err := tc.tw.Find(
+			c.target(b),
+			WithFoundCallback(func(e Event, _ FindFunc) { foundCbEvent = e }),
+			WithFoundChan(foundChan),
+		)
+		if err != nil {
+			t.Fatalf("Find returned error: %v", err)
+		}
+
+		tc.extendTipWait(b)
+
+		if !c.wantFound {
+			// Testing when we don't expect a match.
+
+			assertFoundChanEmpty(t, foundChan)
+			if foundCbEvent != emptyEvent {
+				t.Fatalf("unexpected foundCallback triggered with %s", &foundCbEvent)
+			}
+
+			// Nothing else to test since we didn't expect a match.
+			return
+		}
+
+		// Testing when we expect a match.
+
+		select {
+		case foundChanEvent = <-foundChan:
+		case <-time.After(5 * time.Second):
+			t.Fatal("found chan not triggered in time")
+		}
+
+		if foundCbEvent == emptyEvent {
+			t.Fatal("foundCallback not triggered")
+		}
+
+		if foundChanEvent != foundCbEvent {
+			t.Fatal("cb and chan showed different events")
+		}
+
+		e := foundChanEvent
+		if e.MatchedField != c.wantMF {
+			t.Fatalf("unexpected matched field. want=%s got=%s",
+				c.wantMF, e.MatchedField)
+		}
+
+		if e.BlockHeight != int32(b.block.Header.Height) {
+			t.Fatalf("unexpected matched block height. want=%d got=%d",
+				b.block.Header.Height, e.BlockHeight)
+		}
+
+		if e.BlockHash != b.block.Header.BlockHash() {
+			t.Fatalf("unexpected matched block hash. want=%s got=%s",
+				b.block.Header.BlockHash(), e.BlockHash)
+		}
+
+		// All tests always match against the first transaction in the
+		// block in either the stake or regular transaction tree.
+		var tx *wire.MsgTx
+		var tree int8
+		if len(b.block.Transactions) > 0 {
+			tx = b.block.Transactions[0]
+			tree = wire.TxTreeRegular
+		} else {
+			tx = b.block.STransactions[0]
+			tree = wire.TxTreeStake
+		}
+		if e.Tx.TxHash() != tx.TxHash() {
+			t.Fatalf("unexpected tx match. want=%s got=%s",
+				b.block.Transactions[0].TxHash(), e.Tx.TxHash())
+		}
+
+		// All tests always match against the second input or output.
+		if e.Index != 1 {
+			t.Fatalf("unexpected index match. want=%d got=%d",
+				1, e.Index)
+		}
+
+		if e.Tree != tree {
+			t.Fatalf("unexpected tree match. want=%d got=%d",
+				tree, e.Tree)
+		}
+	}
+
+	for _, c := range scannerTestCases {
+		c := c
+		ok := t.Run(c.name, func(t *testing.T) { runTC(c, t) })
+		if !ok {
+			break
+		}
+	}
+}
+
+// TestTipWatcherCancelation tests that cancelling the watch for a target works
+// as expected.
+func TestTipWatcherCancelation(t *testing.T) {
+	tc := newTwTestCtx(t)
+	defer tc.cleanup()
+
+	foundChan := make(chan Event)
+	cancelChan := make(chan struct{})
+	completeChan := make(chan struct{})
+	tc.tw.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(foundChan),
+		WithCancelChan(cancelChan),
+		WithCompleteChan(completeChan),
+	)
+
+	// Mine a few blocks. We force a full block check to ensure the
+	// behavior under false positives.
+	tc.extendNewTip(cfilterData(testPkScript))
+	tc.extendNewTip(cfilterData(testPkScript))
+	tc.extendNewTip(cfilterData(testPkScript))
+
+	// Ensure none of the channels have been triggered yet
+	select {
+	case <-foundChan:
+		t.Fatal("foundChan unexpectedly triggered")
+	case <-cancelChan:
+		t.Fatal("cancelChan unexpectedly triggered")
+	case <-completeChan:
+		t.Fatal("completeChan unexpectedly triggered")
+	case <-time.After(time.Millisecond * 10):
+	}
+
+	// Generate a new block with a match. This should generate an event in
+	// foundChan.
+	tc.extendNewTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	assertFoundChanRcv(t, foundChan)
+
+	// Cancel the request.
+	close(cancelChan)
+
+	// Generate a new block with a match. We don't expect this will trigger
+	// foundChan given we just canceled the request.
+	tc.extendNewTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+
+	// Still don't expect a signal in complete and found chans.
+	select {
+	case <-foundChan:
+		t.Fatal("foundChan unexpectedly triggered")
+	case <-completeChan:
+		t.Fatal("completeChan unexpectedly triggered")
+	case <-time.After(time.Millisecond * 10):
+	}
+
+}
+
+// TestTipWatcherStaleCompletion tests that watching for a target with a
+// specific endHeight triggers completion.
+func TestTipWatcherStaleCompletion(t *testing.T) {
+	tc := newTwTestCtx(t)
+	defer tc.cleanup()
+
+	foundChan := make(chan Event)
+	cancelChan := make(chan struct{})
+	completeChan := make(chan struct{})
+	tc.tw.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(foundChan),
+		WithCancelChan(cancelChan),
+		WithCompleteChan(completeChan),
+		WithEndHeight(5),
+	)
+
+	// Mine a few blocks. We force a full block check to ensure the
+	// behavior under false positives.
+	tc.extendNewTip(cfilterData(testPkScript))
+	tc.extendNewTip(cfilterData(testPkScript))
+
+	// Ensure none of the channels have been triggered yet.
+	select {
+	case <-foundChan:
+		t.Fatal("foundChan unexpectedly triggered")
+	case <-cancelChan:
+		t.Fatal("cancelChan unexpectedly triggered")
+	case <-completeChan:
+		t.Fatal("completeChan unexpectedly triggered")
+	case <-time.After(time.Millisecond * 10):
+	}
+
+	// Generate a new block with a match. This should generate an event in
+	// foundChan.
+	tc.extendNewTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	assertFoundChanRcvHeight(t, foundChan, int32(tc.chain.tip.block.Header.Height))
+
+	// Generate blocks until endHeight. The completeChan should be closed
+	// by then.
+	tc.extendNewTip(cfilterData(testPkScript))
+	tc.extendNewTip(cfilterData(testPkScript))
+	assertCompleted(t, completeChan)
+
+	// Generate a new block with a match. We don't expect this will trigger
+	// foundChan given the request already completed.
+	tc.extendNewTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+
+	// Still don't expect a signal in found chans.
+	assertFoundChanEmpty(t, foundChan)
+}
+
+// TestTipWatcherReorg tests that when a reorg occurs that causes the NextTip()
+// function to go back to a previous height, watched targets are triggered even
+// if they weren't triggered in the previous chain.
+func TestTipWatcherReorg(t *testing.T) {
+	tc := newTwTestCtx(t)
+	defer tc.cleanup()
+
+	foundChan := make(chan Event)
+	completeChan := make(chan struct{})
+	tc.tw.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(foundChan),
+		WithCompleteChan(completeChan),
+	)
+
+	// Mine a few blocks. We force a full block check to ensure the
+	// behavior under false positives.
+	forkRoot := tc.extendNewTip(cfilterData(testPkScript))
+	tc.extendNewTip(cfilterData(testPkScript))
+	tc.extendNewTip(cfilterData(testPkScript))
+	forkedTip := tc.extendNewTip(cfilterData(testPkScript))
+
+	// Ensure none of the channels have been triggered yet.
+	select {
+	case <-foundChan:
+		t.Fatal("foundChan unexpectedly triggered")
+	case <-completeChan:
+		t.Fatal("completeChan unexpectedly triggered")
+	case <-time.After(time.Millisecond * 10):
+	}
+
+	// Force a reorg. We rewind the tip to the forkRoot point and generate
+	// new blocks from there. The last generated block matches the desired
+	// target at a height lower than the previous forked tip.
+	tc.chain.tip = forkRoot
+	tc.extendNewTip(cfilterData(testPkScript))
+	newTip := tc.extendNewTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+
+	// foundChan should have been triggered.
+	foundEvent := assertFoundChanRcv(t, foundChan)
+
+	// The height of the match should be the new tip and this tip should be
+	// at a height lower than the forked tip.
+	wantHeight := int32(newTip.block.Header.Height)
+	if foundEvent.BlockHeight != wantHeight {
+		t.Fatalf("Event not triggered at correct height. want=%d got=%d",
+			wantHeight, foundEvent.BlockHeight)
+	}
+	if wantHeight >= int32(forkedTip.block.Header.Height) {
+		t.Fatalf("New tip has height higher than forked tip. new=%d forked=%d",
+			wantHeight, forkedTip.block.Header.Height)
+	}
+
+	// Generate blocks until the new chain has a higher height than the
+	// forked tip.
+	for tc.chain.tip.block.Header.Height <= forkedTip.block.Header.Height {
+		tc.extendNewTip(cfilterData(testPkScript))
+	}
+
+	// Finally generate a new match to ensure the TipWatcher is still
+	// finding the target.
+	tc.extendNewTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+
+	select {
+	case <-completeChan:
+		t.Fatal("completeChan unexpectedly signalled")
+	case <-foundChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for foundChan")
+	}
+}
+
+// TestTipWatcherMultipleMatchesInBlock tests that the historical search
+// correctly sends multiple events when the same script is confirmed multiple
+// times in a single block.
+func TestTipWatcherMultipleMatchesInBlock(t *testing.T) {
+	tc := newTwTestCtx(t)
+	defer tc.cleanup()
+
+	foundChan := make(chan Event)
+	tc.tw.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundChan(foundChan),
+	)
+
+	newTip := tc.chain.newFromTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+	// Create an additional output.
+	newTip.block.Transactions[0].AddTxOut(&wire.TxOut{PkScript: testPkScript})
+	tc.chain.extend(newTip)
+	tc.chain.signalNewTip()
+
+	// foundChan should be triggered two (and only two) times.
+	e1 := assertFoundChanRcv(t, foundChan)
+	e2 := assertFoundChanRcv(t, foundChan)
+	assertFoundChanEmpty(t, foundChan)
+
+	// However the events should *not* be exactly the same: the script was
+	// confirmed in two different outputs.
+	if e1 == e2 {
+		t.Fatal("script confirmed twice in the same output")
+	}
+}
+
+// TestTipWatcherBlockDownload tests that TipWatcher only downloads blocks for
+// which the cfilter has passed.
+func TestTipWatcherBlockDownload(t *testing.T) {
+	tc := newTwTestCtx(t)
+	defer tc.cleanup()
+
+	tc.tw.Find(
+		ConfirmedScript(0, testPkScript),
+	)
+
+	// Extend the tip with 2 blocks where the cfilter matches the watched
+	// content and 3 where it doesn't.
+	tc.extendNewTip(cfilterData(testPkScript))
+	tc.extendNewTip()
+	tc.extendNewTip()
+	tc.extendNewTip(cfilterData(testPkScript))
+	tc.extendNewTip()
+
+	// We only expect fetches for 2 blocks of data.
+	wantGetBlockCount := uint32(2)
+	if tc.chain.getBlockCount != wantGetBlockCount {
+		t.Fatalf("Unexpected getBlockCount. want=%d got=%d",
+			wantGetBlockCount, tc.chain.getBlockCount)
+	}
+}
+
+// TestTipWatcherStartWatchHeight tests whether the correct height is returned
+// when starting to watch for a target.
+func TestTipWatcherStartWatchHeight(t *testing.T) {
+	tc := newTwTestCtx(t)
+	defer tc.cleanup()
+
+	swhChan := make(chan int32)
+	var gotHeight int32
+
+	// Switch to the regular asynchronous version of Find() since that's
+	// what is used in production.
+	tc.tw.syncFind = false
+
+	// Test watching when the chain is synced and "quiet".
+	tc.tw.Find(
+		ConfirmedScript(0, testPkScript),
+		WithStartWatchHeightChan(swhChan),
+	)
+	wantHeight := tc.chain.tip.block.Header.Height
+	gotHeight = assertStartWatchHeightSignalled(t, swhChan)
+	if wantHeight != uint32(gotHeight) {
+		t.Fatalf("Unexpected start watching height. want=%d got=%d",
+			wantHeight, gotHeight)
+	}
+
+	// Test watching when the target is watched for in the middle of tip
+	// processing. Note we haven't read from t.tw.tipProcessed so the tip
+	// still hasn't been fully processed.
+	newTip := tc.chain.newFromTip(cfilterData(testPkScript))
+	tc.chain.extend(newTip)
+	tc.chain.signalNewTip()
+
+	// Give it enough time for the tip to start being processed.
+	time.Sleep(10 * time.Millisecond)
+
+	// Try to find the target again.
+	tc.tw.Find(
+		ConfirmedScript(0, testPkScript),
+		WithStartWatchHeightChan(swhChan),
+	)
+
+	// Give it enough time to block.
+	time.Sleep(10 * time.Millisecond)
+
+	// Finish processing tip.
+	select {
+	case <-tc.tw.tipProcessed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for tipProcessed")
+	}
+
+	// We should see the target being watched for after the _new_ tip (vs
+	// the one that was in the middle of processing when we tried to add
+	// the target).
+	wantHeight = newTip.block.Header.Height
+	gotHeight = assertStartWatchHeightSignalled(t, swhChan)
+	if wantHeight != uint32(gotHeight) {
+		t.Fatalf("Unexpected start watching height. want=%d got=%d",
+			wantHeight, gotHeight)
+	}
+}
+
+// TestTipWatcherMultipleFinds tests whether attempting to find multiple times
+// the same target works as expected.
+func TestTipWatcherMultipleFinds(t *testing.T) {
+
+	runTC := func(c scannerTestCase, t *testing.T) {
+		tc := newTwTestCtx(t)
+		defer tc.cleanup()
+
+		b := tc.chain.newFromTip(c.manglers...)
+
+		// Start two searches for the same pkscript.
+		foundChan1 := make(chan Event)
+		foundChan2 := make(chan Event)
+		tc.tw.Find(
+			c.target(b),
+			WithFoundChan(foundChan1),
+		)
+		tc.tw.Find(
+			c.target(b),
+			WithFoundChan(foundChan2),
+		)
+
+		// Confirm it.
+		tc.extendTipWait(b)
+
+		// The two foundChans should be signalled.
+		event1 := assertFoundChanRcvHeight(t, foundChan1, int32(b.block.Header.Height))
+		event2 := assertFoundChanRcv(t, foundChan2)
+		if event1 != event2 {
+			t.Fatalf("Different events returned: %s vs %s", &event1, &event2)
+		}
+	}
+
+	// Test against all variants of targets.
+	for _, c := range scannerTestCases {
+		if !c.wantFound {
+			continue
+		}
+		c := c
+		ok := t.Run(c.name, func(t *testing.T) { runTC(c, t) })
+		if !ok {
+			break
+		}
+	}
+}
+
+// TestTipWatcherAddNewTarget tests that adding a new target during a
+// foundCallback works as expected.
+func TestTipWatcherAddNewTarget(t *testing.T) {
+	tc := newTwTestCtx(t)
+	defer tc.cleanup()
+
+	// Disable syncFind so Find() won't deadlock during foundCb.
+	tc.tw.syncFind = false
+
+	// foundChan should only be triggered in a block _after_ the foundCb
+	// callback is called.
+	cancelChan := make(chan struct{})
+	foundChan := make(chan Event)
+	swhChan := make(chan int32)
+	foundCb := func(e Event, _ FindFunc) {
+		close(cancelChan) // Prevent repeated calls of foundCb.
+		tc.tw.Find(
+			ConfirmedScript(0, testPkScript),
+			WithFoundChan(foundChan),
+			WithStartWatchHeightChan(swhChan),
+		)
+	}
+	tc.tw.Find(
+		ConfirmedScript(0, testPkScript),
+		WithFoundCallback(foundCb),
+		WithCancelChan(cancelChan),
+	)
+
+	// Give it enough time for the new target to register in the scanner.
+	time.Sleep(10 * time.Millisecond)
+
+	// Extend the chain with 2 blocks without the target script and then
+	// one block with the target script (which triggers foundCb).
+	tc.extendNewTip(cfilterData(testPkScript))
+	tc.extendNewTip(cfilterData(testPkScript))
+	tc.extendNewTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+
+	// foundChan shoulnd't have been signalled yet.
+	assertFoundChanEmpty(t, foundChan)
+
+	// But the new search should have started.
+	assertStartWatchHeightSignalled(t, swhChan)
+
+	// Extend the chain with a new block with the taget script. We expect
+	// foundChan to be triggered now, but only once.
+	tc.extendNewTip(
+		confirmScript(testPkScript),
+		cfilterData(testPkScript),
+	)
+
+	assertFoundChanRcvHeight(t, foundChan, int32(tc.chain.tip.block.Header.Height))
+	assertFoundChanEmpty(t, foundChan)
+}
+
+// TestTipWatcherAddNewTargetDuringFcb tests that adding a new target during a
+// foundCallback to be searched starting at the same block works as expected.
+func TestTipWatcherAddNewTargetDuringFcb(t *testing.T) {
+
+	runTC := func(c scannerTestCase, t *testing.T) {
+		tc := newTwTestCtx(t)
+		defer tc.cleanup()
+
+		b := tc.chain.newFromTip(c.manglers...)
+		dupeTestTx(b)
+
+		// The found callback is called for the main find below and
+		// adds a new target that signals via foundChan.
+		foundChan := make(chan Event)
+		foundCb := func(e Event, addNew FindFunc) {
+			assertNoError(t, addNew(
+				c.target(b),
+				WithFoundChan(foundChan),
+			))
+		}
+
+		tc.tw.Find(
+			c.target(b),
+			WithFoundCallback(foundCb),
+		)
+
+		// Confirm it.
+		tc.extendTipWait(b)
+
+		// We expect foundChan to receive one (and only one) event.
+		assertFoundChanRcv(t, foundChan)
+		assertFoundChanEmpty(t, foundChan)
+	}
+
+	// Test against all variants of targets.
+	for _, c := range scannerTestCases {
+		if !c.wantFound {
+			continue
+		}
+		c := c
+		ok := t.Run(c.name, func(t *testing.T) { runTC(c, t) })
+		if !ok {
+			break
+		}
+	}
+
+}

--- a/chainscan/util_test.go
+++ b/chainscan/util_test.go
@@ -1,0 +1,398 @@
+package chainscan
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/gcs/v2"
+	"github.com/decred/dcrd/gcs/v2/blockcf2"
+	"github.com/decred/dcrd/wire"
+)
+
+var (
+	testBlockCounter uint32
+
+	testPkScript = []byte{
+		0x76, 0xa9, 0x14, 0x2b, 0xf4, 0x0a, 0x13, 0xea,
+		0x4f, 0xf1, 0xf9, 0xd3, 0x5a, 0x54, 0x15, 0xb0,
+		0xf7, 0x7d, 0x9e, 0x5d, 0xd9, 0x3b, 0x23, 0x88,
+		0xac,
+	}
+	testSigScript = []byte{
+		0x47, 0x30, 0x44, 0x2, 0x20, 0x7b, 0xe8, 0x26,
+		0xed, 0x10, 0x5f, 0xaf, 0x88, 0xb1, 0x7d, 0x1,
+		0x72, 0x43, 0xd, 0x76, 0x3a, 0x9a, 0x14, 0x99,
+		0x8f, 0x2a, 0x96, 0x12, 0x4b, 0x7c, 0x70, 0x4d,
+		0xa1, 0x4d, 0x96, 0x20, 0xc2, 0x2, 0x20, 0x45,
+		0x8e, 0xf, 0x98, 0x11, 0x3b, 0x35, 0xa2, 0x2d,
+		0x43, 0xfc, 0x2, 0xdf, 0xa4, 0xe, 0x17, 0x8,
+		0xf7, 0xd8, 0xc7, 0x5f, 0xfe, 0xcd, 0x8e, 0x50,
+		0x2c, 0xfd, 0x58, 0xda, 0x4a, 0x2b, 0x10, 0x1,
+		0x21, 0x2, 0x6e, 0xa2, 0xca, 0x26, 0x16, 0x56,
+		0xe6, 0xbc, 0xae, 0xd9, 0xb2, 0x32, 0xdc, 0xc4,
+		0x7b, 0x30, 0x33, 0x20, 0x41, 0xbc, 0x31, 0xd5,
+		0x3c, 0x40, 0xa8, 0xa1, 0x4a, 0xb9, 0x60, 0x4f,
+		0x25, 0x33,
+	}
+	testOutPoint = wire.OutPoint{
+		Hash: chainhash.Hash{
+			0x72, 0x43, 0x0d, 0x76, 0x3a, 0x9a, 0x14, 0x99,
+			0x8f, 0x2a, 0x96, 0x12, 0x4b, 0x7c, 0x70, 0x4d,
+			0x43, 0xfc, 0x02, 0xdf, 0xa4, 0x0e, 0x17, 0x08,
+			0xf7, 0xd8, 0xc7, 0x5f, 0xfe, 0xcd, 0x8e, 0x50,
+		},
+		Index: 1701,
+	}
+
+	emptyEvent Event
+)
+
+// testingIntf matches both *testing.T and *testing.B
+type testingIntf interface {
+	Fatal(...interface{})
+	Fatalf(string, ...interface{})
+	Helper()
+}
+
+func assertFoundChanRcv(t testingIntf, c chan Event) Event {
+	t.Helper()
+
+	var e Event
+	select {
+	case e = <-c:
+		return e
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for receive in foundChan")
+	}
+	return e
+}
+
+func assertFoundChanRcvHeight(t testingIntf, c chan Event, wantHeight int32) Event {
+	t.Helper()
+
+	e := assertFoundChanRcv(t, c)
+	if e.BlockHeight != wantHeight {
+		t.Fatalf("Unexpected BlockHeight in foundChan event. want=%d got=%d",
+			wantHeight, e.BlockHeight)
+	}
+	return e
+}
+
+func assertFoundChanEmpty(t testingIntf, c chan Event) {
+	t.Helper()
+	select {
+	case <-c:
+		t.Fatal("Unexpected signal in foundChan")
+	case <-time.After(10 * time.Millisecond):
+	}
+}
+
+func assertStartWatchHeightSignalled(t testingIntf, c chan int32) int32 {
+	t.Helper()
+
+	var endHeight int32
+	select {
+	case endHeight = <-c:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for start watch height chan signal")
+	}
+	return endHeight
+}
+
+func assertNoError(t testingIntf, err error) {
+	t.Helper()
+
+	if err == nil {
+		return
+	}
+
+	t.Fatalf("Unexpected error: %v", err)
+}
+
+// assertCompleted asserts that the 'c' chan (which should be a completeChan
+// passed to a scanner) is closed in a reasonable time.
+func assertCompleted(t testingIntf, c chan struct{}) {
+	t.Helper()
+	select {
+	case <-c:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for completeChan to close")
+	}
+}
+
+type testBlock struct {
+	block     *wire.MsgBlock
+	blockHash chainhash.Hash
+	cfilter   *gcs.FilterV2
+	cfKey     [16]byte
+}
+
+type blockMangler struct {
+	txMangler    func(tx *wire.MsgTx)
+	blockMangler func(b *wire.MsgBlock)
+	cfilterData  []byte
+}
+
+func spendOutPoint(outp wire.OutPoint) blockMangler {
+	return blockMangler{
+		txMangler: func(tx *wire.MsgTx) {
+			tx.AddTxIn(wire.NewTxIn(&outp, 0, nil))
+		},
+	}
+}
+
+func spendScript(sigScript []byte) blockMangler {
+	var outp wire.OutPoint
+	rand.Read(outp.Hash[:])
+	return blockMangler{
+		txMangler: func(tx *wire.MsgTx) {
+			tx.AddTxIn(wire.NewTxIn(&outp, 0, sigScript))
+		},
+	}
+}
+
+func confirmScript(pkScript []byte) blockMangler {
+	return blockMangler{
+		txMangler: func(tx *wire.MsgTx) {
+			tx.AddTxOut(wire.NewTxOut(0, pkScript))
+		},
+	}
+}
+
+func moveRegularToStakeTree() blockMangler {
+	return blockMangler{
+		blockMangler: func(b *wire.MsgBlock) {
+			b.STransactions = b.Transactions
+			b.Transactions = make([]*wire.MsgTx, 0)
+		},
+	}
+}
+
+func cfilterData(pkScript []byte) blockMangler {
+	return blockMangler{
+		cfilterData: pkScript,
+	}
+}
+
+func newTestBlock(height int32, prevBlock chainhash.Hash, blockManglers ...blockMangler) *testBlock {
+	bc := atomic.AddUint32(&testBlockCounter, 1)
+	tx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{
+				PreviousOutPoint: wire.OutPoint{
+					Index: bc, // Ensure unique tx hash
+				},
+			},
+		},
+		TxOut: []*wire.TxOut{
+			{
+				PkScript: []byte{0x6a},
+			},
+		},
+	}
+	var cfData [][]byte
+	for _, m := range blockManglers {
+		if m.txMangler != nil {
+			m.txMangler(tx)
+		}
+		if m.cfilterData != nil {
+			cfData = append(cfData, m.cfilterData)
+		}
+	}
+
+	block := &wire.MsgBlock{
+		Header: wire.BlockHeader{
+			PrevBlock: prevBlock,
+			Height:    uint32(height),
+			Nonce:     testBlockCounter,
+		},
+		Transactions: []*wire.MsgTx{tx},
+	}
+	binary.LittleEndian.PutUint32(block.Header.MerkleRoot[:], bc)
+
+	for _, m := range blockManglers {
+		if m.blockMangler != nil {
+			m.blockMangler(block)
+		}
+	}
+
+	var cfKey [16]byte
+	copy(cfKey[:], block.Header.MerkleRoot[:])
+	cf, err := gcs.NewFilterV2(blockcf2.B, blockcf2.M, cfKey, cfData)
+	if err != nil {
+		panic(err)
+	}
+
+	return &testBlock{
+		block:     block,
+		blockHash: block.BlockHash(),
+		cfilter:   cf,
+		cfKey:     cfKey,
+	}
+}
+
+// dupeTestTx duplicates the first transaction of the test block (in either the
+// regular or stake transaction trees).
+func dupeTestTx(b *testBlock) {
+	if len(b.block.Transactions) > 0 {
+		b.block.Transactions = append(b.block.Transactions, b.block.Transactions[0])
+	} else {
+		b.block.STransactions = append(b.block.STransactions, b.block.STransactions[0])
+	}
+}
+
+type mockChain struct {
+	// blocks and byHeight are sync.Maps to avoid triggering the race
+	// detector for the chain.
+	blocks   *sync.Map // map[chainhash.Hash]*testBlock
+	byHeight *sync.Map // map[int32]*testBlock
+
+	tipMtx sync.Mutex
+	tip    *testBlock
+
+	mtx          sync.Mutex
+	eventReaders []*eventReader
+
+	newTipChan          chan struct{}
+	getBlockCount       uint32
+	getCfilterCount     uint32
+	sendNextCfilterChan chan struct{}
+}
+
+func newMockChain() *mockChain {
+	return &mockChain{
+		blocks:     &sync.Map{},
+		byHeight:   &sync.Map{},
+		newTipChan: make(chan struct{}),
+	}
+}
+
+func (mc *mockChain) newFromTip(manglers ...blockMangler) *testBlock {
+	var height int32
+	var prevBlock chainhash.Hash
+	mc.tipMtx.Lock()
+	if mc.tip != nil {
+		height = int32(mc.tip.block.Header.Height + 1)
+		prevBlock = mc.tip.block.BlockHash()
+	}
+	mc.tipMtx.Unlock()
+
+	b := newTestBlock(height, prevBlock, manglers...)
+	bh := b.block.BlockHash()
+	mc.blocks.Store(bh, b)
+	mc.byHeight.Store(height, b)
+	return b
+}
+
+func (mc *mockChain) extend(b *testBlock) {
+	mc.tipMtx.Lock()
+	mc.tip = b
+	mc.tipMtx.Unlock()
+}
+
+func (mc *mockChain) signalNewTip() {
+	mc.mtx.Lock()
+	readers := mc.eventReaders
+	mc.mtx.Unlock()
+
+	mc.tipMtx.Lock()
+	tip := mc.tip
+	mc.tipMtx.Unlock()
+
+	e := BlockConnectedEvent{
+		Hash:     tip.blockHash,
+		Height:   int32(tip.block.Header.Height),
+		PrevHash: tip.block.Header.PrevBlock,
+		CFKey:    tip.cfKey,
+		Filter:   tip.cfilter,
+	}
+	for _, r := range readers {
+		select {
+		case <-r.ctx.Done():
+		case r.c <- e:
+		}
+	}
+}
+
+func (mc *mockChain) genBlocks(n int, manglers ...blockMangler) {
+	for i := 0; i < n; i++ {
+		mc.extend(mc.newFromTip(manglers...))
+	}
+}
+
+func (mc *mockChain) ChainEvents(ctx context.Context) <-chan ChainEvent {
+	r := &eventReader{
+		ctx: ctx,
+		c:   make(chan ChainEvent),
+	}
+	mc.mtx.Lock()
+	mc.eventReaders = append(mc.eventReaders, r)
+	mc.mtx.Unlock()
+	return r.c
+}
+
+func (mc *mockChain) NextTip(ctx context.Context) (*chainhash.Hash, int32, [16]byte, *gcs.FilterV2, error) {
+	select {
+	case <-ctx.Done():
+		return nil, 0, [16]byte{}, nil, ctx.Err()
+	case <-mc.newTipChan:
+		mc.tipMtx.Lock()
+		tip := mc.tip
+		mc.tipMtx.Unlock()
+		return &tip.blockHash, int32(tip.block.Header.Height), tip.cfKey, tip.cfilter, nil
+	}
+}
+
+func (mc *mockChain) GetBlock(ctx context.Context, bh *chainhash.Hash) (*wire.MsgBlock, error) {
+	if b, ok := mc.blocks.Load(*bh); ok {
+		atomic.AddUint32(&mc.getBlockCount, 1)
+		return b.(*testBlock).block, nil
+	}
+	return nil, errors.New("block not found")
+}
+
+func (mc *mockChain) CurrentTip(ctx context.Context) (*chainhash.Hash, int32, error) {
+	mc.tipMtx.Lock()
+	tip := mc.tip
+	mc.tipMtx.Unlock()
+
+	if tip == nil {
+		return nil, 0, errors.New("chain uninitialized")
+	}
+
+	return &tip.blockHash, int32(tip.block.Header.Height), nil
+}
+
+func (mc *mockChain) GetCFilter(ctx context.Context, height int32) (*chainhash.Hash, [16]byte, *gcs.FilterV2, error) {
+	// If sendNextCfilter is specified then wait until it's signalled by
+	// the test routine to send the cfilter.
+	if mc.sendNextCfilterChan != nil {
+		<-mc.sendNextCfilterChan
+	}
+
+	mc.tipMtx.Lock()
+	tip := mc.tip
+	mc.tipMtx.Unlock()
+	if tip == nil {
+		return nil, [16]byte{}, nil, errors.New("chain unitialized")
+	}
+
+	if height > int32(tip.block.Header.Height) {
+		return nil, [16]byte{}, nil, ErrBlockAfterTip{Height: height}
+	}
+
+	bl, ok := mc.byHeight.Load(height)
+	if !ok {
+		return nil, [16]byte{}, nil, fmt.Errorf("unknown block by height %d", height)
+	}
+	block := bl.(*testBlock)
+	atomic.AddUint32(&mc.getCfilterCount, 1)
+	return &block.blockHash, block.cfKey, block.cfilter, nil
+}

--- a/contractcourt/chain_watcher_test.go
+++ b/contractcourt/chain_watcher_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrlnd/chainntnfs"
+	"github.com/decred/dcrlnd/chainscan"
 	"github.com/decred/dcrlnd/channeldb"
 	"github.com/decred/dcrlnd/input"
 	"github.com/decred/dcrlnd/lnwallet"
@@ -288,7 +289,7 @@ func TestChainWatcherCorrectSpendNtnf(t *testing.T) {
 			ntnfReq.outpoint)
 	}
 
-	_, err = chainntnfs.ParsePkScript(0, ntnfReq.pkScript)
+	_, err = chainscan.ParsePkScript(0, ntnfReq.pkScript)
 	if err != nil {
 		t.Fatalf("unable to parse watched pkscript: %v", err)
 	}

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/decred/dcrd/wire"
 
 	"github.com/decred/dcrlnd/chainntnfs"
+	"github.com/decred/dcrlnd/chainscan"
 	"github.com/decred/dcrlnd/chanacceptor"
 	"github.com/decred/dcrlnd/channeldb"
 	"github.com/decred/dcrlnd/discovery"
@@ -120,7 +121,7 @@ func (m *mockNotifier) confirmTx(t *testing.T, tx *wire.MsgTx) {
 func (m *mockNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 	pkScript []byte, numConfs, heightHint uint32) (*chainntnfs.ConfirmationEvent, error) {
 
-	_, err := chainntnfs.ParsePkScript(0, pkScript)
+	_, err := chainscan.ParsePkScript(0, pkScript)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/decred/dcrd/dcrutil v1.4.0
 	github.com/decred/dcrd/dcrutil/v2 v2.0.1
 	github.com/decred/dcrd/dcrutil/v3 v3.0.0-20200608124004-b2f67c2dc475
+	github.com/decred/dcrd/gcs/v2 v2.0.2-0.20200608124004-b2f67c2dc475
 	github.com/decred/dcrd/hdkeychain/v2 v2.1.0
 	github.com/decred/dcrd/hdkeychain/v3 v3.0.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v2 v2.0.1-0.20200503044000-76f6906e50e5

--- a/log.go
+++ b/log.go
@@ -7,6 +7,8 @@ import (
 	"github.com/decred/dcrlnd/autopilot"
 	"github.com/decred/dcrlnd/build"
 	"github.com/decred/dcrlnd/chainntnfs"
+	"github.com/decred/dcrlnd/chainscan"
+	"github.com/decred/dcrlnd/chainscan/csdrivers"
 	"github.com/decred/dcrlnd/chanbackup"
 	"github.com/decred/dcrlnd/chanfitness"
 	"github.com/decred/dcrlnd/channeldb"
@@ -109,6 +111,8 @@ func init() {
 	addSubLogger("DCRW", dcrwallet.UseLogger)
 	addSubLogger("RDCW", remotedcrwallet.UseLogger)
 	addSubLogger("KCHN", keychain.UseLogger)
+	addSubLogger("CSCN", chainscan.UseLogger)
+	addSubLogger("CSDR", csdrivers.UseLogger)
 }
 
 // addSubLogger is a helper method to conveniently create and register the


### PR DESCRIPTION
Part of #80 

(Still missing some documentation, examples and copyright notice on the package.)

This introduces a new package called `chainscan`. The primary goal for this package is to be able to perform historical and tip-changed-triggered scans of blocks to determine whether they have relevant transactions for the LN node and retrieve the ones that are.

This is an improvement over the existing manual rescan performed by the the dcrd node via LoadTxFilter as done today in dcrlnd in that it checks the cfilters for the wanted targets before attempting to iterate over the block's transactions.

It is also a necessary step towards supporting SPV mode, given that in that mode the LN node does not have access to a full chain.

The package is self-contained and has minimal external dependencies. The implemented scanners (`Historical` and `TipWatcher`) require that the caller provide implementations for the chain operations necessary for the search to happen, so this package is usable by callers retrieving their information from a running dcrd instance, a dcrwallet instance or from some other source of blockchain data. This makes it suitable for use by software other than dcrlnd.

A set of tests and benchmarks is included.