### PR TITLE
Improve build meta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ IOS_BUILD := $(IOS_BUILD_DIR)/Lndmobile.framework
 ANDROID_BUILD_DIR := $(MOBILE_BUILD_DIR)/android
 ANDROID_BUILD := $(ANDROID_BUILD_DIR)/Lndmobile.aar
 
-COMMIT := $(shell git describe --abbrev=40 --dirty)
+WTDIRTY := $(shell git diff-index --quiet HEAD -- || echo "-dirty" || echo "")
+COMMIT := $(shell git log -1 --format="%H$(WTDIRTY)")
 LDFLAGS := -ldflags "-X $(FULLPKG)/build.Commit=$(COMMIT)"
 
 DCRD_COMMIT := $(shell cat go.mod | \

--- a/build/version.go
+++ b/build/version.go
@@ -43,7 +43,7 @@ var (
 	// '-ldflags "-X github.com/decred/dcrlnd/build.BuildMetadata=foo"'
 	// if needed.  It MUST only contain characters from semanticBuildAlphabet
 	// per the semantic versioning spec.
-	BuildMetadata = "dev"
+	BuildMetadata = ""
 
 	// Commit is defined as a variable so it can be overriden during the
 	// build process with:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -78,29 +78,20 @@ related dependencies run the following commands:
 ```
 go get -d github.com/decred/dcrlnd
 cd $GOPATH/src/github.com/decred/dcrlnd
-make && make install
+go install ./cmd/dcrlnd
+go install ./cmd/dcrlncli
 ```
 
 **NOTE**: Our instructions still use the `$GOPATH` directory from prior
 versions of Go, but with go 1.11, it's now possible for `dcrlnd` to live
 _anywhere_ on your file system.
 
-For Windows WSL users, make will need to be referenced directly via
-/usr/bin/make/, or alternatively by wrapping quotation marks around make,
-like so:
+Alternatively, if you want to automatically include commit metadata on your
+binary (which might help debugging issues or keeping track of things when
+running multiple versions simultaneously) you can use `make`:
 
 ```
-/usr/bin/make && /usr/bin/make install
-
-"make" && "make" install
-```
-
-On FreeBSD, use gmake instead of make.
-
-Alternatively, if one doesn't wish to use `make`, then the `go` commands can be
-used directly:
-```
-GO111MODULE=on go install -v ./...
+make install
 ```
 
 **Updating**
@@ -110,17 +101,8 @@ commands:
 ```
 cd $GOPATH/src/github.com/decred/dcrlnd
 git pull
-make clean && make && make install
-```
-
-On FreeBSD, use gmake instead of make.
-
-Alternatively, if one doesn't wish to use `make`, then the `go` commands can be
-used directly:
-```
-cd $GOPATH/src/github.com/decred/dcrlnd
-git pull
-GO111MODULE=on go install -v ./...
+go install ./cmd/dcrlnd
+go install ./cmd/dcrlncli
 ```
 
 **Tests**
@@ -154,17 +136,16 @@ dcrd:
 
 ### Installing dcrd
 
-On FreeBSD, use gmake instead of make.
+Use the official [dcrd install
+instructions](https://github.com/decred/dcrd/#installing-and-updating),
+preferably with one of the release-worthy builds.
 
-To install dcrd, run the following commands:
+Alternatively, when setting up a new machine for testing you can use `make` to
+install a dcrd version that is compatible with dcrlnd:
 
-Install **dcrd**:
 ```
 make dcrd
 ```
-
-Alternatively, you can install [`dcrd` directly from its
-repo](https://github.com/decred/dcrd).
 
 ### Starting dcrd
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,9 +2,11 @@
 
 Super quick start, for knowledgeable individuals.
 
-- Use Go >= 1.11
+- Use Go >= 1.13
 - Git clone as usual
-- `make install`
+- Install as usual:
+  - `go install ./cmd/dcrlnd`
+  - `go install ./cmd/dcrlncli`
 - These should now work:
   - `dcrlnd --version`
   - `dcrlncli --version`


### PR DESCRIPTION
Improve some build elements now that build tags have been inverted. This:

- Switches the version metadata to use the new standard for decred software
- Switches the commit data generated by `make` to be less confusing
- Switches the instructions to use `go install` instead of `make` (:tada: :tada:)