### PR TITLE
github: Switch to go1.14

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.12, 1.13]
+        go: [1.13, 1.14]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v1
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.13]
+        go: [1.14]
         testsuite: ["unit-race", "itest-only", "itest-only walletimpl=remotewallet"]
     steps:
       - name: Set up Go

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -53,12 +53,12 @@ UNIT_TARGETED ?= no
 # targeted case. Otherwise, default to running all tests.
 ifeq ($(UNIT_TARGETED), yes)
 UNIT := $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS) $(UNITPKG)
-UNIT_RACE := $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS) -race $(UNITPKG)
+UNIT_RACE := $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS) -race -gcflags=all=-d=checkptr=0 $(UNITPKG)
 endif
 
 ifeq ($(UNIT_TARGETED), no)
 UNIT := $(GOLIST) | $(XARGS) env $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS)
-UNIT_RACE := $(UNIT) -race
+UNIT_RACE := $(UNIT) -race -gcflags=all=-d=checkptr=0
 endif
 
 


### PR DESCRIPTION
This switches the Github Actions CI to perform tests using go versions
1.13 and 1.14 versus the previous 1.12 and 1.13.

