### PR TITLE
Fix typo in dcrlncli commands

### DIFF
--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -199,38 +199,38 @@ var sendCoinsCommand = cli.Command{
 	Description: `
 	Send amt coins in atoms to the BASE58 encoded decred address addr.
 
-	Fees used when sending the transaction can be specified via the --conf_target, or
-	--atoms_per_byte optional flags.
+	Fees used when sending the transaction can be specified via the '--conf_target', or
+	'--atoms_per_byte' optional flags.
 
 	Positional arguments and flags can be used interchangeably but not at the same time!
 	`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "addr",
-			Usage: "the BASE58 encoded decred address to send coins to on-chain",
+			Usage: "The BASE58 encoded decred address to send coins to on-chain",
 		},
 		cli.BoolFlag{
 			Name: "sweepall",
-			Usage: "if set, then the amount field will be ignored, " +
+			Usage: "If set, then the amount field will be ignored, " +
 				"and all the wallet will attempt to sweep all " +
 				"outputs within the wallet to the target " +
 				"address",
 		},
 		cli.Int64Flag{
 			Name:  "amt",
-			Usage: "the number of decred denominated in atoms to send",
+			Usage: "The number of decred denominated in atoms to send",
 		},
 		cli.Int64Flag{
 			Name: "conf_target",
-			Usage: "(optional) the number of blocks that the " +
+			Usage: "The number of blocks that the " +
 				"transaction *should* confirm in, will be " +
-				"used for fee estimation",
+				"used for fee estimation (optional)",
 		},
 		cli.Int64Flag{
 			Name: "atoms_per_byte",
-			Usage: "(optional) a manual fee expressed in " +
+			Usage: "A manual fee expressed in " +
 				"atoms/byte that should be used when crafting " +
-				"the transaction",
+				"the transaction (optional)",
 		},
 	},
 	Action: actionDecorator(sendCoins),
@@ -250,7 +250,7 @@ func sendCoins(ctx *cli.Context) error {
 	}
 
 	if ctx.IsSet("conf_target") && ctx.IsSet("atoms_per_byte") {
-		return fmt.Errorf("either conf_target or atoms_per_byte should be " +
+		return fmt.Errorf("either --conf_target or --atoms_per_byte should be " +
 			"set, but not both")
 	}
 

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -3208,7 +3208,7 @@ var decodePayReqCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "pay_req",
-			Usage: "the bech32 encoded payment request",
+			Usage: "The bech32 encoded payment request",
 		},
 	},
 	Action: actionDecorator(decodePayReq),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -3964,8 +3964,8 @@ var restoreChanBackupCommand = cli.Command{
 	ArgsUsage: "[--single_backup] [--multi_backup] [--multi_file=",
 	Description: `
 	Allows a user to restore a Static Channel Backup (SCB) that was
-	obtained either via the exportchanbackup command, or from lnd's
-	automatically manged channels.backup file. This command should be used
+	obtained either via the 'exportchanbackup' command, or from lnd's
+	automatically manged 'channels.backup' file. This command should be used
 	if a user is attempting to restore a channel due to data loss on a
 	running node restored with the same seed as the node that created the
 	channel. If successful, this command will allows the user to recover
@@ -3974,29 +3974,29 @@ var restoreChanBackupCommand = cli.Command{
 	The command will accept backups in one of three forms:
 
 	   * A single channel packed SCB, which can be obtained from
-	     exportchanbackup. This should be passed in hex encoded format.
+	     'exportchanbackup'. This should be passed in hex encoded format.
 
 	   * A packed multi-channel SCB, which couples several individual
 	     static channel backups in single blob.
 
 	   * A file path which points to a packed multi-channel backup within a
-	     file, using the same format that lnd does in its channels.backup
+	     file, using the same format that dcrlnd does in its 'channels.backup'
 	     file.
 	`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "single_backup",
-			Usage: "a hex encoded single channel backup obtained " +
+			Usage: "A hex encoded single channel backup obtained " +
 				"from exportchanbackup",
 		},
 		cli.StringFlag{
 			Name: "multi_backup",
-			Usage: "a hex encoded multi-channel backup obtained " +
+			Usage: "A hex encoded multi-channel backup obtained " +
 				"from exportchanbackup",
 		},
 		cli.StringFlag{
 			Name:  "multi_file",
-			Usage: "the path to a multi-channel back up file",
+			Usage: "The path to a multi-channel back up file",
 		},
 	},
 	Action: actionDecorator(restoreChanBackup),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -304,13 +304,13 @@ func sendCoins(ctx *cli.Context) error {
 var listUnspentCommand = cli.Command{
 	Name:      "listunspent",
 	Category:  "On-chain",
-	Usage:     "List utxos available for spending.",
+	Usage:     "List UTXOs available for spending.",
 	ArgsUsage: "[min-confs [max-confs]] [--unconfirmed_only]",
 	Description: `
-	For each spendable utxo currently in the wallet, with at least min_confs
-	confirmations, and at most max_confs confirmations, lists the txid,
+	For each spendable UTXO currently in the wallet, with at least 'min_confs'
+	confirmations, and at most 'max_confs' confirmations, lists the txid,
 	index, amount, address, address type, scriptPubkey and number of
-	confirmations.  Use --min_confs=0 to include unconfirmed coins. To list
+	confirmations.  Use '--min_confs=0' to include unconfirmed coins. To list
 	all coins with at least min_confs confirmations, omit the second
 	argument or flag '--max_confs'. To list all confirmed and unconfirmed
 	coins, no arguments are required. To see only unconfirmed coins, use
@@ -320,19 +320,19 @@ var listUnspentCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.Int64Flag{
 			Name:  "min_confs",
-			Usage: "the minimum number of confirmations for a utxo",
+			Usage: "The minimum number of confirmations for a UTXO",
 		},
 		cli.Int64Flag{
 			Name:  "max_confs",
-			Usage: "the maximum number of confirmations for a utxo",
+			Usage: "The maximum number of confirmations for a UTXO",
 		},
 		cli.BoolFlag{
 			Name: "unconfirmed_only",
-			Usage: "when min_confs and max_confs are zero, " +
-				"setting false implicitly overrides max_confs " +
-				"to be MaxInt32, otherwise max_confs remains " +
+			Usage: "When min_confs and max_confs are zero, " +
+				"setting false implicitly overrides 'max_confs' " +
+				"to be MaxInt32, otherwise 'max_confs' remains " +
 				"zero. An error is returned if the value is " +
-				"true and both min_confs and max_confs are " +
+				"true and both 'min_confs' and 'max_confs' are " +
 				"non-zero. (default: false)",
 		},
 	},

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -148,14 +148,14 @@ func newAddress(ctx *cli.Context) error {
 var estimateFeeCommand = cli.Command{
 	Name:      "estimatefee",
 	Category:  "On-chain",
-	Usage:     "Get fee estimates for sending bitcoin on-chain to multiple addresses.",
+	Usage:     "Get fee estimates for sending decred on-chain to multiple addresses.",
 	ArgsUsage: "send-json-string [--conf_target=N]",
 	Description: `
 	Get fee estimates for sending a transaction paying the specified amount(s) to the passed address(es).
 
-	The send-json-string' param decodes addresses and the amount to send respectively in the following format:
+	The 'send-json-string' param encodes addresses and the amount to send respectively in the following format:
 
-	    '{"ExampleAddr": NumCoinsInSatoshis, "SecondAddr": NumCoins}'
+	    {"ExampleAddr": NumCoinsInAtoms, "SecondAddr": NumCoins}
 	`,
 	Flags: []cli.Flag{
 		cli.Int64Flag{

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -1962,19 +1962,19 @@ var listChannelsCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "active_only",
-			Usage: "only list channels which are currently active",
+			Usage: "Only list channels which are currently active",
 		},
 		cli.BoolFlag{
 			Name:  "inactive_only",
-			Usage: "only list channels which are currently inactive",
+			Usage: "Only list channels which are currently inactive",
 		},
 		cli.BoolFlag{
 			Name:  "public_only",
-			Usage: "only list channels which are currently public",
+			Usage: "Only list channels which are currently public",
 		},
 		cli.BoolFlag{
 			Name:  "private_only",
-			Usage: "only list channels which are currently private",
+			Usage: "Only list channels which are currently private",
 		},
 	},
 	Action: actionDecorator(listChannels),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -2641,19 +2641,19 @@ var addInvoiceCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "memo",
-			Usage: "a description of the payment to attach along " +
+			Usage: "A description of the payment to attach along " +
 				"with the invoice (default=\"\")",
 		},
 		cli.StringFlag{
 			Name: "preimage",
-			Usage: "the hex-encoded preimage (32 byte) which will " +
+			Usage: "The hex-encoded preimage (32 byte) which will " +
 				"allow settling an incoming HTLC payable to this " +
 				"preimage. If not set, a random preimage will be " +
 				"created.",
 		},
 		cli.Int64Flag{
 			Name:  "amt",
-			Usage: "the amt of atoms in this invoice",
+			Usage: "The amt of atoms in this invoice",
 		},
 		cli.StringFlag{
 			Name: "description_hash",
@@ -2665,24 +2665,24 @@ var addInvoiceCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name: "fallback_addr",
-			Usage: "fallback on-chain address that can be used in " +
+			Usage: "Fallback on-chain address that can be used in " +
 				"case the lightning payment fails",
 		},
 		cli.Int64Flag{
 			Name: "expiry",
-			Usage: "the invoice's expiry time in seconds. If not " +
+			Usage: "The invoice's expiry time in seconds. If not " +
 				"specified an expiry of 3600 seconds (1 hour) " +
 				"is implied.",
 		},
 		cli.BoolTFlag{
 			Name: "private",
-			Usage: "encode routing hints in the invoice with " +
+			Usage: "Encode routing hints in the invoice with " +
 				"private channels in order to assist the " +
 				"payer in reaching you",
 		},
 		cli.BoolFlag{
 			Name: "ignore_max_inbound_amt",
-			Usage: "ignore check for available inbound capacity " +
+			Usage: "Ignore check for available inbound capacity " +
 				"in directly connected channels and create the " +
 				"invoice anyway.",
 		},

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -1746,12 +1746,12 @@ var unlockCommand = cli.Command{
 	The unlock command is used to decrypt dcrlnd's wallet state in order to
 	start up. This command MUST be run after booting up dcrlnd before it's
 	able to carry out its duties. An exception is if a user is running with
-	--noseedbackup, then a default passphrase will be used.
+	'--noseedbackup', then a default passphrase will be used.
 	`,
 	Flags: []cli.Flag{
 		cli.IntFlag{
 			Name: "recovery_window",
-			Usage: "address lookahead to resume recovery rescan, " +
+			Usage: "Address lookahead to resume recovery rescan, " +
 				"value should be non-zero --  To recover all " +
 				"funds, this should be greater than the " +
 				"maximum number of consecutive, unused " +

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -2439,8 +2439,8 @@ var payInvoiceCommand = cli.Command{
 	Flags: append(paymentFlags(),
 		cli.Int64Flag{
 			Name: "amt",
-			Usage: "(optional) number of atoms to fulfill the " +
-				"invoice",
+			Usage: "Number of atoms to fulfill the " +
+				"invoice (optional)",
 		},
 	),
 	Action: actionDecorator(payInvoice),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -2944,7 +2944,7 @@ var getChanInfoCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.Int64Flag{
 			Name:  "chan_id",
-			Usage: "the 8-byte compact channel ID to query for",
+			Usage: "The 8-byte compact channel ID to query for",
 		},
 	},
 	Action: actionDecorator(getChanInfo),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -3344,11 +3344,11 @@ var verifyMessageCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "msg",
-			Usage: "the message to verify",
+			Usage: "The message to verify",
 		},
 		cli.StringFlag{
 			Name:  "sig",
-			Usage: "the zbase32 encoded signature of the message",
+			Usage: "The zbase32 encoded signature of the message",
 		},
 	},
 	Action: actionDecorator(verifyMessage),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -579,8 +579,8 @@ var openChannelCommand = cli.Command{
 	optionally blocking until the channel is 'open'.
 
 	One can also connect to a node before opening a new channel to it by
-	setting its host:port via the --connect argument. For this to work,
-	the node_key must be provided, rather than the peer_id. This is optional.
+	setting its host:port via the '--connect' argument. For this to work,
+	the 'node_key' must be provided, rather than the 'peer_id'. This is optional.
 
 	The channel will be initialized with 'local-amt' atoms locally and 'push-amt'
 	atoms for the remote node. Note that specifying push-amt means you give that
@@ -588,13 +588,13 @@ var openChannelCommand = cli.Command{
 	a 'channelPoint' ('txid:vout') of the funding output is returned.
 
 	If the remote peer supports the option upfront shutdown feature bit (query 
-	listpeers to see their supported feature bits), an address to enforce
+	'listpeers' to see their supported feature bits), an address to enforce
 	payout of funds on cooperative close can optionally be provided. Note that
 	if you set this value, you will not be able to cooperatively close out to
 	another address.
 
 	One can manually set the fee to be used for the funding transaction via either
-	the --conf_target or --atoms_per_byte arguments. This is optional.`,
+	the '--conf_target' or '--atoms_per_byte' arguments. This is optional.`,
 	ArgsUsage: "node-key local-amt push-amt",
 	Flags: []cli.Flag{
 		cli.StringFlag{

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -3898,23 +3898,23 @@ var verifyChanBackupCommand = cli.Command{
 	 static channel backups in single blob.
 
        * A file path which points to a packed multi-channel backup within a
-	 file, using the same format that lnd does in its channels.backup
+	 file, using the same format that dcrlnd does in its 'channels.backup'
 	 file.
     `,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "single_backup",
-			Usage: "a hex encoded single channel backup obtained " +
-				"from exportchanbackup",
+			Usage: "A hex encoded single channel backup obtained " +
+				"from 'exportchanbackup'",
 		},
 		cli.StringFlag{
 			Name: "multi_backup",
-			Usage: "a hex encoded multi-channel backup obtained " +
-				"from exportchanbackup",
+			Usage: "A hex encoded multi-channel backup obtained " +
+				"from 'exportchanbackup'",
 		},
 		cli.StringFlag{
 			Name:  "multi_file",
-			Usage: "the path to a multi-channel back up file",
+			Usage: "The path to a multi-channel back up file",
 		},
 	},
 	Action: actionDecorator(verifyChanBackup),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -3299,7 +3299,7 @@ var signMessageCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "msg",
-			Usage: "the message to sign",
+			Usage: "The message to sign",
 		},
 	},
 	Action: actionDecorator(signMessage),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -1230,7 +1230,7 @@ func promptForConfirmation(msg string) bool {
 var abandonChannelCommand = cli.Command{
 	Name:     "abandonchannel",
 	Category: "Channels",
-	Usage:    "Abandons an existing channel.",
+	Usage:    "Abandon an existing channel.",
 	Description: `
 	Removes all channel state from the database except for a close
 	summary. This method can be used to get rid of permanently unusable
@@ -1238,18 +1238,18 @@ var abandonChannelCommand = cli.Command{
 
 	Only available when dcrlnd is built in debug mode.
 
-	To view which funding_txids/output_indexes can be used for this command,
-	see the channel_point values within the listchannels command output.
-	The format for a channel_point is 'funding_txid:output_index'.`,
+	To view which 'funding_txids' or 'output_indexes' can be used for this command,
+	see the 'channel_point' values within the 'listchannels' command output.
+	The format for a 'channel_point' is 'funding_txid:output_index'.`,
 	ArgsUsage: "funding_txid [output_index]",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "funding_txid",
-			Usage: "the txid of the channel's funding transaction",
+			Usage: "The txid of the channel's funding transaction",
 		},
 		cli.IntFlag{
 			Name: "output_index",
-			Usage: "the output index for the funding output of the funding " +
+			Usage: "The output index for the funding output of the funding " +
 				"transaction",
 		},
 	},

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -430,21 +430,21 @@ var sendManyCommand = cli.Command{
 	Description: `
 	Create and broadcast a transaction paying the specified amount(s) to the passed address(es).
 
-	The send-json-string' param decodes addresses and the amount to send
+	The 'send-json-string' param decodes addresses and the amount to send
 	respectively in the following format:
 
-	    '{"ExampleAddr": NumCoinsInAtoms, "SecondAddr": NumCoins}'
+	    {"ExampleAddr": NumCoinsInAtoms, "SecondAddr": NumCoins}
 	`,
 	Flags: []cli.Flag{
 		cli.Int64Flag{
 			Name: "conf_target",
-			Usage: "(optional) the number of blocks that the transaction *should* " +
-				"confirm in, will be used for fee estimation",
+			Usage: "The number of blocks that the transaction *should* " +
+				"confirm in, will be used for fee estimation (optional)",
 		},
 		cli.Int64Flag{
 			Name: "atoms_per_byte",
-			Usage: "(optional) a manual fee expressed in atom/byte that should be " +
-				"used when crafting the transaction",
+			Usage: "Manual fee expressed in atom/byte that should be " +
+				"used when crafting the transaction (optional)",
 		},
 	},
 	Action: actionDecorator(sendMany),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -2759,7 +2759,7 @@ var lookupInvoiceCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "rhash",
-			Usage: "the 32 byte payment hash of the invoice to query for, the hash " +
+			Usage: "The 32 byte payment hash of the invoice to query for, the hash " +
 				"should be a hex-encoded string",
 		},
 	},

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -2994,12 +2994,12 @@ var getNodeInfoCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "pub_key",
-			Usage: "the 33-byte hex-encoded compressed public of the target " +
+			Usage: "The 33-byte hex-encoded compressed public of the target " +
 				"node",
 		},
 		cli.BoolFlag{
 			Name: "include_channels",
-			Usage: "if true, will return all known channels " +
+			Usage: "If true, will return all known channels " +
 				"associated with the node",
 		},
 	},

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -2911,7 +2911,7 @@ var listPaymentsCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "include_incomplete",
-			Usage: "if set to true, payments still in flight (or failed) will be returned as well",
+			Usage: "If set to true, payments still in flight (or failed) will be returned as well",
 		},
 	},
 	Action: actionDecorator(listPayments),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -3046,31 +3046,31 @@ var queryRoutesCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "dest",
-			Usage: "the 33-byte hex-encoded public key for the payment " +
+			Usage: "The 33-byte hex-encoded public key for the payment " +
 				"destination",
 		},
 		cli.Int64Flag{
 			Name:  "amt",
-			Usage: "the amount to send expressed in atoms",
+			Usage: "The amount to send expressed in atoms",
 		},
 		cli.Int64Flag{
 			Name: "fee_limit",
-			Usage: "maximum fee allowed in atoms when sending " +
+			Usage: "Maximum fee allowed in atoms when sending " +
 				"the payment",
 		},
 		cli.Int64Flag{
 			Name: "fee_limit_percent",
-			Usage: "percentage of the payment's amount used as the " +
+			Usage: "Percentage of the payment's amount used as the " +
 				"maximum fee allowed when sending the payment",
 		},
 		cli.Int64Flag{
 			Name: "final_cltv_delta",
-			Usage: "(optional) number of blocks the last hop has to reveal " +
-				"the preimage",
+			Usage: "Number of blocks the last hop has to reveal " +
+				"the preimage (optional)",
 		},
 		cli.BoolFlag{
 			Name:  "use_mc",
-			Usage: "use mission control probabilities",
+			Usage: "Use mission control probabilities",
 		},
 		cltvLimitFlag,
 	},

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -1008,39 +1008,39 @@ var closeAllChannelsCommand = cli.Command{
 	settled funds within it will be time locked for a few blocks before they
 	can be spent.
 
-	One can request to close inactive channels only by using the
-	--inactive_only flag.
+	You can request to close inactive channels only by using the
+	'--inactive_only' flag.
 
-	By default, one is prompted for confirmation every time an inactive
+	By default, confirmation is prompted each time an inactive
 	channel is requested to be closed. To avoid this, one can set the
-	--force flag, which will only prompt for confirmation once for all
+	'--force' flag, which will only prompt for confirmation once for all
 	inactive channels and proceed to close them.
 
 	In the case of cooperative closures, one can manually set the fee to
-	be used for the closing transactions via either the --conf_target or
-	--atoms_per_byte arguments. This will be the starting value used during
+	be used for the closing transactions via either the '--conf_target' or
+	'--atoms_per_byte' arguments. This will be the starting value used during
 	fee negotiation. This is optional.`,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "inactive_only",
-			Usage: "close inactive channels only",
+			Usage: "Close inactive channels only",
 		},
 		cli.BoolFlag{
 			Name: "force",
-			Usage: "ask for confirmation once before attempting " +
+			Usage: "Ask for confirmation once before attempting " +
 				"to close existing channels",
 		},
 		cli.Int64Flag{
 			Name: "conf_target",
-			Usage: "(optional) the number of blocks that the " +
+			Usage: "The number of blocks that the " +
 				"closing transactions *should* confirm in, will be " +
-				"used for fee estimation",
+				"used for fee estimation (optional)",
 		},
 		cli.Int64Flag{
 			Name: "atoms_per_byte",
-			Usage: "(optional) a manual fee expressed in " +
-				"sat/byte that should be used when crafting " +
-				"the closing transactions",
+			Usage: "A manual fee expressed in " +
+				"atom/byte that should be used when crafting " +
+				"the closing transactions (optional)",
 		},
 	},
 	Action: actionDecorator(closeAllChannels),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -1816,8 +1816,8 @@ var changePasswordCommand = cli.Command{
 	is successful.
 
 	If one did not specify a password for their wallet (running dcrlnd with
-	--noseedbackup), one must restart their daemon without
-	--noseedbackup and use this command. The "current password" field
+	'--noseedbackup'), one must restart their daemon without
+	'--noseedbackup' and use this command. The "current password" field
 	should be left empty.
 	`,
 	Action: actionDecorator(changePassword),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -2093,16 +2093,16 @@ func paymentFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
 			Name:  "pay_req",
-			Usage: "a zpay32 encoded payment request to fulfill",
+			Usage: "A zpay32 encoded payment request to fulfill",
 		},
 		cli.Int64Flag{
 			Name: "fee_limit",
-			Usage: "maximum fee allowed in satoshis when " +
+			Usage: "Maximum fee allowed in atoms when " +
 				"sending the payment",
 		},
 		cli.Int64Flag{
 			Name: "fee_limit_percent",
-			Usage: "percentage of the payment's amount used as " +
+			Usage: "Percentage of the payment's amount used as " +
 				"the maximum fee allowed when sending the " +
 				"payment",
 		},
@@ -2110,17 +2110,17 @@ func paymentFlags() []cli.Flag {
 		lastHopFlag,
 		cli.Uint64Flag{
 			Name: "outgoing_chan_id",
-			Usage: "short channel id of the outgoing channel to " +
+			Usage: "Short channel id of the outgoing channel to " +
 				"use for the first hop of the payment",
 			Value: 0,
 		},
 		cli.BoolFlag{
 			Name:  "force, f",
-			Usage: "will skip payment request confirmation",
+			Usage: "Will skip payment request confirmation",
 		},
 		cli.BoolFlag{
 			Name:  "allow_self_payment",
-			Usage: "allow sending a circular payment to self",
+			Usage: "Allow sending a circular payment to self",
 		},
 		dataFlag,
 	}
@@ -2136,37 +2136,37 @@ var sendPaymentCommand = cli.Command{
 	all the payment details.
 
 	If payment isn't manually specified, then only a payment request needs
-	to be passed using the --pay_req argument.
+	to be passed using the '--pay_req' argument.
 
 	If the payment *is* manually specified, then all four alternative
 	arguments need to be specified in order to complete the payment:
-	    * --dest=N
-	    * --amt=A
-	    * --final_cltv_delta=T
-	    * --payment_hash=H
+	 * --dest=N
+	 * --amt=A
+	 * --final_cltv_delta=T
+	 * --payment_hash=H
 	`,
 	ArgsUsage: "dest amt payment_hash final_cltv_delta | --pay_req=[payment request]",
 	Flags: append(paymentFlags(),
 		cli.StringFlag{
 			Name: "dest, d",
-			Usage: "the compressed identity pubkey of the " +
+			Usage: "The compressed identity pubkey of the " +
 				"payment recipient",
 		},
 		cli.Int64Flag{
 			Name:  "amt, a",
-			Usage: "number of atoms to send",
+			Usage: "Number of atoms to send",
 		},
 		cli.StringFlag{
 			Name:  "payment_hash, r",
-			Usage: "the hash to use within the payment's HTLC",
+			Usage: "The hash to use within the payment's HTLC",
 		},
 		cli.Int64Flag{
 			Name:  "final_cltv_delta",
-			Usage: "the number of blocks the last hop has to reveal the preimage",
+			Usage: "The number of blocks the last hop has to reveal the preimage",
 		},
 		cli.BoolFlag{
 			Name:  "keysend",
-			Usage: "will generate a pre-image and encode it in the sphinx packet, a dest must be set [experimental]",
+			Usage: "Will generate a pre-image and encode it in the sphinx packet, a dest must be set [experimental]",
 		},
 	),
 	Action: sendPayment,

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -2810,39 +2810,39 @@ var listInvoicesCommand = cli.Command{
 	Description: `
 	This command enables the retrieval of all invoices currently stored
 	within the database. It has full support for paginationed responses,
-	allowing users to query for specific invoices through their add_index.
-	This can be done by using either the first_index_offset or
-	last_index_offset fields included in the response as the index_offset of
+	allowing users to query for specific invoices through their 'add_index'.
+	This can be done by using either the 'first_index_offset' or
+	'last_index_offset' fields included in the response as the 'index_offset' of
 	the next request. The reversed flag is set by default in order to
 	paginate backwards. If you wish to paginate forwards, you must
 	explicitly set the flag to false. If none of the parameters are
 	specified, then the last 100 invoices will be returned.
 
-	For example: if you have 200 invoices, "dcrlncli listinvoices" will return
+	For example: if you have 200 invoices, 'dcrlncli listinvoices' will return
 	the last 100 created. If you wish to retrieve the previous 100, the
-	first_offset_index of the response can be used as the index_offset of
+	'first_offset_index' of the response can be used as the 'index_offset' of
 	the next listinvoices request.`,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name: "pending_only",
-			Usage: "toggles if all invoices should be returned, " +
+			Usage: "Toggles if all invoices should be returned, " +
 				"or only those that are currently unsettled",
 		},
 		cli.Uint64Flag{
 			Name: "index_offset",
-			Usage: "the index of an invoice that will be used as " +
+			Usage: "The index of an invoice that will be used as " +
 				"either the start or end of a query to " +
 				"determine which invoices should be returned " +
 				"in the response",
 		},
 		cli.Uint64Flag{
 			Name:  "max_invoices",
-			Usage: "the max number of invoices to return",
+			Usage: "The max number of invoices to return",
 		},
 		cli.BoolTFlag{
 			Name: "reversed",
-			Usage: "if set, the invoices returned precede the " +
-				"given index_offset, allowing backwards " +
+			Usage: "If set, the invoices returned precede the " +
+				"given 'index_offset', allowing backwards " +
 				"pagination",
 		},
 	},

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -2475,23 +2475,23 @@ var sendToRouteCommand = cli.Command{
 	Description: `
 	Send a payment over Lightning using a specific route. One must specify
 	the route to attempt and the payment hash. This command can even
-	be chained with the response to queryroutes or buildroute. This command
+	be chained with the response to 'queryroutes' or 'buildroute'. This command
 	can be used to implement channel rebalancing by crafting a self-route,
 	or even atomic swaps using a self-route that crosses multiple chains.
 
 	There are three ways to specify a route:
-	   * using the --routes parameter to manually specify a JSON encoded
+	   * using the '--routes' parameter to manually specify a JSON encoded
 	     route in the format of the return value of queryroutes or
 	     buildroute:
-	         (dcrlncli sendtoroute --payment_hash=<pay_hash> --routes=<route>)
+	         'dcrlncli sendtoroute --payment_hash=<pay_hash> --routes=<route>'
 
 	   * passing the route as a positional argument:
-	         (dcrlncli sendtoroute --payment_hash=pay_hash <route>)
+	         ('dcrlncli sendtoroute --payment_hash=pay_hash <route>'
 
 	   * or reading in the route from stdin, which can allow chaining the
-	     response from queryroutes or buildroute, or even read in a file
+	     response from 'queryroutes' or 'buildroute', or even read in a file
 	     with a pre-computed route:
-	         (dcrlncli queryroutes --args.. | dcrlncli sendtoroute --payment_hash= -
+	         'dcrlncli queryroutes --args.. | dcrlncli sendtoroute --payment_hash= -'
 
 	     notice the '-' at the end, which signals that dcrlncli should read
 	     the route in from stdin
@@ -2499,12 +2499,12 @@ var sendToRouteCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "payment_hash, pay_hash",
-			Usage: "the hash to use within the payment's HTLC",
+			Usage: "The hash to use within the payment's HTLC",
 		},
 		cli.StringFlag{
 			Name: "routes, r",
-			Usage: "a json array string in the format of the response " +
-				"of queryroutes that denotes which routes to use",
+			Usage: "A json array string in the format of the response " +
+				"of 'queryroutes' that denotes which routes to use",
 		},
 	},
 	Action: sendToRoute,

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -3401,7 +3401,7 @@ var feeReportCommand = cli.Command{
 	Usage:    "Display the current fee policies of all active channels.",
 	Description: `
 	Returns the current fee policies of all active channels.
-	Fee policies can be updated using the updatechanpolicy command.`,
+	Fee policies can be updated using the 'updatechanpolicy' command.`,
 	Action: actionDecorator(feeReport),
 }
 

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -582,10 +582,10 @@ var openChannelCommand = cli.Command{
 	setting its host:port via the --connect argument. For this to work,
 	the node_key must be provided, rather than the peer_id. This is optional.
 
-	The channel will be initialized with local-amt atoms local and push-amt
+	The channel will be initialized with 'local-amt' atoms locally and 'push-amt'
 	atoms for the remote node. Note that specifying push-amt means you give that
 	amount to the remote node as part of the channel opening. Once the channel is open,
-	a channelPoint (txid:vout) of the funding output is returned.
+	a 'channelPoint' ('txid:vout') of the funding output is returned.
 
 	If the remote peer supports the option upfront shutdown feature bit (query 
 	listpeers to see their supported feature bits), an address to enforce
@@ -599,20 +599,20 @@ var openChannelCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "node_key",
-			Usage: "the identity public key of the target node/peer " +
+			Usage: "The identity public key of the target node/peer " +
 				"serialized in compressed format",
 		},
 		cli.StringFlag{
 			Name:  "connect",
-			Usage: "(optional) the host:port of the target node",
+			Usage: "The host:port of the target node (optional)",
 		},
 		cli.IntFlag{
 			Name:  "local_amt",
-			Usage: "the number of atoms the wallet should commit to the channel",
+			Usage: "The number of atoms the wallet should commit to the channel",
 		},
 		cli.IntFlag{
 			Name: "push_amt",
-			Usage: "the number of atoms to give the remote side " +
+			Usage: "The number of atoms to give the remote side " +
 				"as part of the initial commitment state, " +
 				"this is equivalent to first opening a " +
 				"channel and sending the remote party funds, " +
@@ -620,23 +620,23 @@ var openChannelCommand = cli.Command{
 		},
 		cli.BoolFlag{
 			Name:  "block",
-			Usage: "block and wait until the channel is fully open",
+			Usage: "Block and wait until the channel is fully open",
 		},
 		cli.Int64Flag{
 			Name: "conf_target",
-			Usage: "(optional) the number of blocks that the " +
+			Usage: "The number of blocks that the " +
 				"transaction *should* confirm in, will be " +
-				"used for fee estimation",
+				"used for fee estimation (optional)",
 		},
 		cli.Int64Flag{
 			Name: "atoms_per_byte",
-			Usage: "(optional) a manual fee expressed in " +
+			Usage: "A manual fee expressed in " +
 				"atom/byte that should be used when crafting " +
-				"the transaction",
+				"the transaction (optional)",
 		},
 		cli.BoolFlag{
 			Name: "private",
-			Usage: "make the channel private, such that it won't " +
+			Usage: "Make the channel private, such that it won't " +
 				"be announced to the greater network, and " +
 				"nodes other than the two channel endpoints " +
 				"must be explicitly told about it to be able " +
@@ -644,30 +644,30 @@ var openChannelCommand = cli.Command{
 		},
 		cli.Int64Flag{
 			Name: "min_htlc_m_atoms",
-			Usage: "(optional) the minimum value we will require " +
-				"for incoming HTLCs on the channel",
+			Usage: "The minimum value we will require " +
+				"for incoming HTLCs on the channel (optional)",
 		},
 		cli.Uint64Flag{
 			Name: "remote_csv_delay",
-			Usage: "(optional) the number of blocks we will require " +
+			Usage: "The number of blocks we will require " +
 				"our channel counterparty to wait before accessing " +
 				"its funds in case of unilateral close. If this is " +
 				"not set, we will scale the value according to the " +
-				"channel size",
+				"channel size (optional)",
 		},
 		cli.Uint64Flag{
 			Name: "min_confs",
-			Usage: "(optional) the minimum number of confirmations " +
+			Usage: "The minimum number of confirmations " +
 				"each one of your outputs used for the funding " +
-				"transaction must satisfy",
+				"transaction must satisfy (optional)",
 			Value: 1,
 		},
 		cli.StringFlag{
 			Name: "close_address",
-			Usage: "(optional) an address to enforce payout of our " +
+			Usage: "An address to enforce payout of our " +
 				"funds to on cooperative close. Note that if this " +
 				"value is set on channel open, you will *not* be " +
-				"able to cooperatively close to a different address.",
+				"able to cooperatively close to a different address (optional)",
 		},
 	},
 	Action: actionDecorator(openChannel),
@@ -694,7 +694,7 @@ func openChannel(ctx *cli.Context) error {
 		AtomsPerByte:     ctx.Int64("atoms_per_byte"),
 		MinHtlcMAtoms:    ctx.Int64("min_htlc_m_atoms"),
 		RemoteCsvDelay:   uint32(ctx.Uint64("remote_csv_delay")),
-		MinConfs:         int32(ctx.Uint64("min_confs")),
+		MinConfs:         minConfs,
 		SpendUnconfirmed: minConfs == 0,
 		CloseAddress:     ctx.String("close_address"),
 	}

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -489,8 +489,8 @@ var connectCommand = cli.Command{
 		cli.BoolFlag{
 			Name: "perm",
 			Usage: "If set, the daemon will attempt to persistently " +
-				"connect to the target peer.\n" +
-				"           If not, the call will be synchronous.",
+				"connect to the target peer. " +
+				"If not, the call will be synchronous.",
 		},
 	},
 	Action: actionDecorator(connectPeer),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -1371,23 +1371,23 @@ var createCommand = cli.Command{
 	Finally, it's also possible to use this command and a set of static
 	channel backups to trigger a recover attempt for the provided Static
 	Channel Backups. Only one of the three parameters will be accepted. See
-	the restorechanbackup command for further details w.r.t the format
+	the 'restorechanbackup' command for further details w.r.t the format
 	accepted.
 	`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "single_backup",
-			Usage: "a hex encoded single channel backup obtained " +
+			Usage: "A hex encoded single channel backup obtained " +
 				"from exportchanbackup",
 		},
 		cli.StringFlag{
 			Name: "multi_backup",
-			Usage: "a hex encoded multi-channel backup obtained " +
+			Usage: "A hex encoded multi-channel backup obtained " +
 				"from exportchanbackup",
 		},
 		cli.StringFlag{
 			Name:  "multi_file",
-			Usage: "the path to a multi-channel back up file",
+			Usage: "The path to a multi-channel back up file",
 		},
 	},
 	Action: actionDecorator(create),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -3744,32 +3744,32 @@ var exportChanBackupCommand = cli.Command{
 	     backup containing only the information for that channel will be
 	     returned.
 
-	   * If the --all flag is passed, then a multi-channel backup will be
+	   * If the '--all' flag is passed, then a multi-channel backup will be
 	     returned. A multi backup is a single encrypted blob (displayed in
 	     hex encoding) that contains several channels in a single cipher
 	     text.
 
-	Both of the backup types can be restored using the restorechanbackup
+	Both of the backup types can be restored using the 'restorechanbackup'
 	command.
 	`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "chan_point",
-			Usage: "the target channel to obtain an SCB for",
+			Usage: "The target channel to obtain an SCB for",
 		},
 		cli.BoolFlag{
 			Name: "all",
-			Usage: "if specified, then a multi backup of all " +
+			Usage: "If specified, then a multi backup of all " +
 				"active channels will be returned",
 		},
 		cli.StringFlag{
 			Name: "output_file",
 			Usage: `
-			if specified, then rather than printing a JSON output
+			If specified, then rather than printing a JSON output
 			of the static channel backup, a serialized version of
 			the backup (either Single or Multi) will be written to
-			the target file, this is the same format used by lnd in
-			its channels.backup file `,
+			the target file, this is the same format used by dcrlnd in
+			its 'channels.backup' file `,
 		},
 	},
 	Action: actionDecorator(exportChanBackup),
@@ -3841,7 +3841,7 @@ func exportChanBackup(ctx *cli.Context) error {
 	}
 
 	if !ctx.IsSet("all") {
-		return fmt.Errorf("if a channel isn't specified, -all must be")
+		return fmt.Errorf("if a channel isn't specified, --all must be")
 	}
 
 	chanBackup, err := client.ExportAllChannelBackups(

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -2011,31 +2011,31 @@ var closedChannelsCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "cooperative",
-			Usage: "list channels that were closed cooperatively",
+			Usage: "List channels that were closed cooperatively",
 		},
 		cli.BoolFlag{
 			Name: "local_force",
-			Usage: "list channels that were force-closed " +
+			Usage: "List channels that were force-closed " +
 				"by the local node",
 		},
 		cli.BoolFlag{
 			Name: "remote_force",
-			Usage: "list channels that were force-closed " +
+			Usage: "List channels that were force-closed " +
 				"by the remote node",
 		},
 		cli.BoolFlag{
 			Name: "breach",
-			Usage: "list channels for which the remote node " +
+			Usage: "List channels for which the remote node " +
 				"attempted to broadcast a prior " +
 				"revoked channel state",
 		},
 		cli.BoolFlag{
 			Name:  "funding_canceled",
-			Usage: "list channels that were never fully opened",
+			Usage: "List channels that were never fully opened",
 		},
 		cli.BoolFlag{
 			Name: "abandoned",
-			Usage: "list channels that were abandoned by " +
+			Usage: "List channels that were abandoned by " +
 				"the local node",
 		},
 	},

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -3431,35 +3431,35 @@ var updateChannelPolicyCommand = cli.Command{
 	Updates the channel policy for all channels, or just a particular channel
 	identified by its channel point. The update will be committed, and
 	broadcast to the rest of the network within the next batch.
-	Channel points are encoded as: funding_txid:output_index`,
+	Channel points are encoded as 'funding_txid:output_index'`,
 	Flags: []cli.Flag{
 		cli.Int64Flag{
 			Name: "base_fee_m_atoms",
 			Usage: "the base fee in milli-atoms that will " +
-				"be charged for each forwarded HTLC, regardless " +
+				"Be charged for each forwarded HTLC, regardless " +
 				"of payment size",
 		},
 		cli.StringFlag{
 			Name: "fee_rate",
 			Usage: "the fee rate that will be charged " +
-				"proportionally based on the value of each " +
+				"Proportionally based on the value of each " +
 				"forwarded HTLC, the lowest possible rate is 0 " +
 				"with a granularity of 0.000001 (millionths)",
 		},
 		cli.Int64Flag{
 			Name: "time_lock_delta",
-			Usage: "the CLTV delta that will be applied to all " +
+			Usage: "The CLTV delta that will be applied to all " +
 				"forwarded HTLCs",
 		},
 		cli.Uint64Flag{
 			Name: "min_htlc_m_atoms",
-			Usage: "if set, the min HTLC size that will be applied " +
+			Usage: "If set, the min HTLC size that will be applied " +
 				"to all forwarded HTLCs. If unset, the min HTLC " +
 				"is left unchanged.",
 		},
 		cli.Uint64Flag{
 			Name: "max_htlc_m_atoms",
-			Usage: "if set, the max HTLC size that will be applied " +
+			Usage: "If set, the max HTLC size that will be applied " +
 				"to all forwarded HTLCs. If unset, the max HTLC " +
 				"is left unchanged.",
 		},
@@ -3467,7 +3467,7 @@ var updateChannelPolicyCommand = cli.Command{
 			Name: "chan_point",
 			Usage: "The channel whose fee policy should be " +
 				"updated, if nil the policies for all channels " +
-				"will be updated. Takes the form of: txid:output_index",
+				"will be updated. Takes the form of 'txid:output_index'",
 		},
 	},
 	Action: actionDecorator(updateChannelPolicy),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -3610,37 +3610,37 @@ var forwardingHistoryCommand = cli.Command{
 	ArgsUsage: "start_time [end_time] [index_offset] [max_events]",
 	Description: `
 	Query the HTLC switch's internal forwarding log for all completed
-	payment circuits (HTLCs) over a particular time range (--start_time and
-	--end_time). The start and end times are meant to be expressed in
-	seconds since the Unix epoch. If --start_time isn't provided,
-	then 24 hours ago is used.  If --end_time isn't provided,
+	payment circuits (HTLCs) over a particular time range '--start_time' and
+	'--end_time'. The start and end times are meant to be expressed in
+	seconds since the Unix epoch. If '--start_time' isn't provided,
+	then 24 hours ago is used.  If '--end_time' isn't provided,
 	then the current time is used.
 
 	The max number of events returned is 50k. The default number is 100,
-	callers can use the --max_events param to modify this value.
+	callers can use the '--max_events' param to modify this value.
 
-	Finally, callers can skip a series of events using the --index_offset
+	Finally, callers can skip a series of events using the '--index_offset'
 	parameter. Each response will contain the offset index of the last
 	entry. Using this callers can manually paginate within a time slice.
 	`,
 	Flags: []cli.Flag{
 		cli.Int64Flag{
 			Name: "start_time",
-			Usage: "the starting time for the query, expressed in " +
+			Usage: "The starting time for the query, expressed in " +
 				"seconds since the unix epoch",
 		},
 		cli.Int64Flag{
 			Name: "end_time",
-			Usage: "the end time for the query, expressed in " +
+			Usage: "The end time for the query, expressed in " +
 				"seconds since the unix epoch",
 		},
 		cli.Int64Flag{
 			Name:  "index_offset",
-			Usage: "the number of events to skip",
+			Usage: "The number of events to skip",
 		},
 		cli.Int64Flag{
 			Name:  "max_events",
-			Usage: "the max number of events to return",
+			Usage: "The max number of events to return",
 		},
 	},
 	Action: actionDecorator(forwardingHistory),

--- a/cmd/dcrlncli/commands.go
+++ b/cmd/dcrlncli/commands.go
@@ -840,15 +840,15 @@ var closeChannelCommand = cli.Command{
 	Usage:    "Close an existing channel.",
 	Description: `
 	Close an existing channel. The channel can be closed either cooperatively,
-	or unilaterally (--force).
+	or unilaterally with '--force'.
 
 	A unilateral channel closure means that the latest commitment
 	transaction will be broadcast to the network. As a result, any settled
 	funds will be time locked for a few blocks before they can be spent.
 
 	In the case of a cooperative closure, one can manually set the fee to
-	be used for the closing transaction via either the --conf_target or
-	--atoms_per_byte arguments. This will be the starting value used during
+	be used for the closing transaction via either the '--conf_target' or
+	'--atoms_per_byte' arguments. This will be the starting value used during
 	fee negotiation. This is optional.
 
 	In the case of a cooperative closure, one can manually set the address
@@ -856,46 +856,46 @@ var closeChannelCommand = cli.Command{
 	if an upfront shutdown address has not already been set. If neither are
 	set the funds will be delivered to a new wallet address.
 
-	To view which funding_txids/output_indexes can be used for a channel close,
-	see the channel_point values within the listchannels command output.
-	The format for a channel_point is 'funding_txid:output_index'.`,
+	To view which 'funding_txids' or 'output_indexes' can be used for a channel close,
+	see the 'channel_point' values within the 'listchannels' command output.
+	The format for a 'channel_point' is 'funding_txid:output_index'.`,
 	ArgsUsage: "funding_txid [output_index]",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "funding_txid",
-			Usage: "the txid of the channel's funding transaction",
+			Usage: "The txid of the channel's funding transaction",
 		},
 		cli.IntFlag{
 			Name: "output_index",
-			Usage: "the output index for the funding output of the funding " +
+			Usage: "The output index for the funding output of the funding " +
 				"transaction",
 		},
 		cli.BoolFlag{
 			Name:  "force",
-			Usage: "attempt an uncooperative closure",
+			Usage: "Attempt an uncooperative closure",
 		},
 		cli.BoolFlag{
 			Name:  "block",
-			Usage: "block until the channel is closed",
+			Usage: "Block until the channel is closed",
 		},
 		cli.Int64Flag{
 			Name: "conf_target",
-			Usage: "(optional) the number of blocks that the " +
+			Usage: "The number of blocks that the " +
 				"transaction *should* confirm in, will be " +
-				"used for fee estimation",
+				"used for fee estimation (optional)",
 		},
 		cli.Int64Flag{
 			Name: "atoms_per_byte",
-			Usage: "(optional) a manual fee expressed in " +
+			Usage: "A manual fee expressed in " +
 				"atom/byte that should be used when crafting " +
-				"the transaction",
+				"the transaction (optional)",
 		},
 		cli.StringFlag{
 			Name: "delivery_addr",
-			Usage: "(optional) an address to deliver funds " +
+			Usage: "An address to deliver funds " +
 				"upon cooperative channel closing, may only " +
 				"be used if an upfront shutdown addresss is not" +
-				"already set",
+				"already set (optional)",
 		},
 	},
 	Action: actionDecorator(closeChannel),
@@ -927,7 +927,7 @@ func closeChannel(ctx *cli.Context) error {
 
 	// After parsing the request, we'll spin up a goroutine that will
 	// retrieve the closing transaction ID when attempting to close the
-	// channel. We do this to because `executeChannelClose` can block, so we
+	// channel. We do this because `executeChannelClose` can block, so we
 	// would like to present the closing transaction ID to the user as soon
 	// as it is broadcasted.
 	var wg sync.WaitGroup

--- a/cmd/dcrlncli/invoicesrpc_active.go
+++ b/cmd/dcrlncli/invoicesrpc_active.go
@@ -42,7 +42,7 @@ var settleInvoiceCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "preimage",
-			Usage: "the hex-encoded preimage (32 byte) which will " +
+			Usage: "The hex-encoded preimage (32 byte) which will " +
 				"allow settling an incoming HTLC payable to this " +
 				"preimage.",
 		},

--- a/cmd/dcrlncli/invoicesrpc_active.go
+++ b/cmd/dcrlncli/invoicesrpc_active.go
@@ -148,21 +148,21 @@ var addHoldInvoiceCommand = cli.Command{
 
 	Invoices without an amount can be created by not supplying any
 	parameters or providing an amount of 0. These invoices allow the payee
-	to specify the amount of satoshis they wish to send.`,
+	to specify the amount of atoms they wish to send.`,
 	ArgsUsage: "hash [amt]",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "memo",
-			Usage: "a description of the payment to attach along " +
+			Usage: "A description of the payment to attach along " +
 				"with the invoice (default=\"\")",
 		},
 		cli.Int64Flag{
 			Name:  "amt",
-			Usage: "the amt of atoms in this invoice",
+			Usage: "The amt of atoms in this invoice",
 		},
 		cli.Int64Flag{
 			Name:  "amt_m_atoms",
-			Usage: "the amt of milliatoms in this invoice",
+			Usage: "The amt of milliatoms in this invoice",
 		},
 		cli.StringFlag{
 			Name: "description_hash",
@@ -174,18 +174,18 @@ var addHoldInvoiceCommand = cli.Command{
 		},
 		cli.StringFlag{
 			Name: "fallback_addr",
-			Usage: "fallback on-chain address that can be used in " +
+			Usage: "Fallback on-chain address that can be used in " +
 				"case the lightning payment fails",
 		},
 		cli.Int64Flag{
 			Name: "expiry",
-			Usage: "the invoice's expiry time in seconds. If not " +
+			Usage: "The invoice's expiry time in seconds. If not " +
 				"specified, an expiry of 3600 seconds (1 hour) " +
 				"is implied.",
 		},
 		cli.BoolTFlag{
 			Name: "private",
-			Usage: "encode routing hints in the invoice with " +
+			Usage: "Encode routing hints in the invoice with " +
 				"private channels in order to assist the " +
 				"payer in reaching you",
 		},

--- a/cmd/dcrlncli/invoicesrpc_active.go
+++ b/cmd/dcrlncli/invoicesrpc_active.go
@@ -96,7 +96,7 @@ var cancelInvoiceCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name: "paymenthash",
-			Usage: "the hex-encoded payment hash (32 byte) for which the " +
+			Usage: "The hex-encoded payment hash (32 byte) for which the " +
 				"corresponding invoice will be canceled.",
 		},
 	},


### PR DESCRIPTION
Fix typos in `dcrlncli` based on #88 