### PR TITLE
Add wallet-backed chainntnfs implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ lnwallet/.miner-logs*
 chainscan/csdrivers/.*
 chainscan/csdrivers/*.log
 chainntnfs/*.log
+chainntnfs/.miner-logs*
 
 cmd/cmd
 *.key

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ lnwallet/output*.log
 lnwallet/.miner-logs*
 chainscan/csdrivers/.*
 chainscan/csdrivers/*.log
+chainntnfs/*.log
 
 cmd/cmd
 *.key

--- a/chainntnfs/chainscannotify/csnotify.go
+++ b/chainntnfs/chainscannotify/csnotify.go
@@ -1,0 +1,934 @@
+package csnotify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/chaincfg/v2"
+	"github.com/decred/dcrd/dcrutil/v3"
+	"github.com/decred/dcrd/gcs/v2"
+	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrlnd/chainntnfs"
+	"github.com/decred/dcrlnd/chainscan"
+	"github.com/decred/dcrlnd/queue"
+)
+
+var (
+	// ErrChainNotifierShuttingDown is used when we are trying to
+	// measure a spend notification when notifier is already stopped.
+	ErrChainNotifierShuttingDown = errors.New("chainntnfs: system interrupt " +
+		"while attempting to register for spend notification")
+)
+
+type ChainSource interface {
+	GetBlock(context.Context, *chainhash.Hash) (*wire.MsgBlock, error)
+	CurrentTip(context.Context) (*chainhash.Hash, int32, error)
+
+	ChainEvents(context.Context) <-chan chainscan.ChainEvent
+
+	GetCFilter(context.Context, int32) (*chainhash.Hash, [16]byte, *gcs.FilterV2, error)
+
+	GetBlockHash(context.Context, int32) (*chainhash.Hash, error)
+	GetBlockHeader(context.Context, *chainhash.Hash) (*wire.BlockHeader, error)
+	StoresReorgedHeaders() bool
+
+	Run(context.Context) error
+}
+
+// chainConn adapts a ChainSource (plus a context) into a chainntf.ChainConn
+type chainConn struct {
+	c            ChainSource
+	ctx          context.Context
+	storesReorgs bool
+}
+
+func (c *chainConn) GetBlockHash(height int64) (*chainhash.Hash, error) {
+	return c.c.GetBlockHash(c.ctx, int32(height))
+}
+
+func (c *chainConn) GetBlockHeader(hash *chainhash.Hash) (*wire.BlockHeader, error) {
+	return c.c.GetBlockHeader(c.ctx, hash)
+}
+
+// ChainscanNotifier implements the ChainNotifier interface by using the
+// chainscan package components.  Multiple concurrent clients are supported.
+// All notifications are achieved via non-blocking sends on client channels.
+//
+// NOTE: This assumes for the moment the backing chain source is a dcrwallet
+// instance (either embedded or remote) so it makes assumptions about the kinds
+// of things the wallet stores and how it behaves.
+type ChainscanNotifier struct {
+	epochClientCounter uint64 // To be used atomically.
+
+	started int32 // To be used atomically.
+	stopped int32 // To be used atomically.
+
+	ctx       context.Context
+	cancelCtx func()
+
+	tipWatcherTxs map[chainhash.Hash]map[*wire.MsgTx]chainscan.Event
+
+	historical  *chainscan.Historical
+	tipWatcher  *chainscan.TipWatcher
+	chainConn   *chainConn
+	chainEvents <-chan chainscan.ChainEvent
+
+	chainParams *chaincfg.Params
+
+	notificationCancels  chan interface{}
+	notificationRegistry chan interface{}
+
+	txNotifier *chainntnfs.TxNotifier
+
+	blockEpochClients map[uint64]*blockEpochRegistration
+
+	bestBlock chainntnfs.BlockEpoch
+
+	chainUpdates *queue.ConcurrentQueue
+
+	// spendHintCache is a cache used to query and update the latest height
+	// hints for an outpoint. Each height hint represents the earliest
+	// height at which the outpoint could have been spent within the chain.
+	spendHintCache chainntnfs.SpendHintCache
+
+	// confirmHintCache is a cache used to query the latest height hints for
+	// a transaction. Each height hint represents the earliest height at
+	// which the transaction could have confirmed within the chain.
+	confirmHintCache chainntnfs.ConfirmHintCache
+
+	wg   sync.WaitGroup
+	quit chan struct{}
+}
+
+// Ensure ChainscanNotifier implements the ChainNotifier interface at compile time.
+var _ chainntnfs.ChainNotifier = (*ChainscanNotifier)(nil)
+
+// New returns a new ChainscanNotifier instance. This function assumes the dcrd node
+// detailed in the passed configuration is already running, and willing to
+// accept new websockets clients.
+func New(chainSrc ChainSource,
+	chainParams *chaincfg.Params, spendHintCache chainntnfs.SpendHintCache,
+	confirmHintCache chainntnfs.ConfirmHintCache) (*ChainscanNotifier, error) {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	chainConn := &chainConn{
+		c:            chainSrc,
+		ctx:          ctx,
+		storesReorgs: chainSrc.StoresReorgedHeaders(),
+	}
+
+	historical := chainscan.NewHistorical(chainSrc)
+	tipWatcher := chainscan.NewTipWatcher(chainSrc)
+
+	notifier := &ChainscanNotifier{
+		chainParams: chainParams,
+
+		historical:    historical,
+		tipWatcher:    tipWatcher,
+		chainConn:     chainConn,
+		tipWatcherTxs: make(map[chainhash.Hash]map[*wire.MsgTx]chainscan.Event),
+
+		ctx:       ctx,
+		cancelCtx: cancel,
+
+		notificationCancels:  make(chan interface{}),
+		notificationRegistry: make(chan interface{}),
+
+		blockEpochClients: make(map[uint64]*blockEpochRegistration),
+
+		chainUpdates: queue.NewConcurrentQueue(10),
+
+		spendHintCache:   spendHintCache,
+		confirmHintCache: confirmHintCache,
+
+		quit: make(chan struct{}),
+	}
+
+	return notifier, nil
+}
+
+func runAndLogOnError(ctx context.Context, f func(context.Context) error, name string) {
+	go func() {
+		err := f(ctx)
+		select {
+		case <-ctx.Done():
+			// Any errs were due to done() so, ok
+			return
+		default:
+		}
+		if err != nil {
+			chainntnfs.Log.Errorf("CSNotify error while running %s: %v", name, err)
+		}
+	}()
+}
+
+// Start connects to the running dcrd node over websockets, registers for block
+// notifications, and finally launches all related helper goroutines.
+func (n *ChainscanNotifier) Start() error {
+	// Already started?
+	if atomic.AddInt32(&n.started, 1) != 1 {
+		return nil
+	}
+
+	chainntnfs.Log.Infof("Starting chainscan notifier")
+
+	runAndLogOnError(n.ctx, n.chainConn.c.Run, "chainConn")
+	runAndLogOnError(n.ctx, n.tipWatcher.Run, "tipWatcher")
+	runAndLogOnError(n.ctx, n.historical.Run, "historical")
+
+	n.chainEvents = n.tipWatcher.ChainEvents(n.ctx)
+	n.chainUpdates.Start()
+
+	currentHash, currentHeight, err := n.chainConn.c.CurrentTip(n.ctx)
+	if err != nil {
+		n.chainUpdates.Stop()
+		return err
+	}
+
+	chainntnfs.Log.Debugf("Starting txnotifier at height %d hash %s",
+		currentHeight, currentHash)
+
+	n.txNotifier = chainntnfs.NewTxNotifier(
+		uint32(currentHeight), chainntnfs.ReorgSafetyLimit,
+		n.confirmHintCache, n.spendHintCache, n.chainParams,
+	)
+
+	n.bestBlock = chainntnfs.BlockEpoch{
+		Height: currentHeight,
+		Hash:   currentHash,
+	}
+
+	n.wg.Add(2)
+	go n.notificationDispatcher()
+	go n.handleChainEvents()
+
+	return nil
+}
+
+// Stop shutsdown the ChainscanNotifier.
+func (n *ChainscanNotifier) Stop() error {
+	// Already shutting down?
+	if atomic.AddInt32(&n.stopped, 1) != 1 {
+		return nil
+	}
+
+	chainntnfs.Log.Debug("ChainscanNotifier shutting down")
+
+	// Cancel any outstanding request.
+	n.cancelCtx()
+
+	close(n.quit)
+	n.wg.Wait()
+
+	n.chainUpdates.Stop()
+
+	// Notify all pending clients of our shutdown by closing the related
+	// notification channels.
+	for _, epochClient := range n.blockEpochClients {
+		close(epochClient.cancelChan)
+		epochClient.wg.Wait()
+
+		close(epochClient.epochChan)
+	}
+	n.txNotifier.TearDown()
+
+	chainntnfs.Log.Info("ChainscanNotifier shut down")
+
+	return nil
+}
+
+// filteredBlock represents a new block which has been connected to the main
+// chain. The slice of transactions will only be populated if the block
+// includes a transaction that confirmed one of our watched txids, or spends
+// one of the outputs currently being watched.
+type filteredBlock struct {
+	hash     *chainhash.Hash
+	height   int32
+	prevHash *chainhash.Hash
+
+	txns []*dcrutil.Tx
+
+	// connected is true if this update is a new block and false if it is a
+	// disconnected block.
+	connect bool
+}
+
+// foundAtTip is called by the tipWatcher whenever a watched target matches.
+func (n *ChainscanNotifier) foundAtTip(e chainscan.Event, _ chainscan.FindFunc) {
+	chainntnfs.Log.Tracef("Found at tip bh %s: %s", e.BlockHash, e)
+	txs, ok := n.tipWatcherTxs[e.BlockHash]
+	if !ok {
+		txs = make(map[*wire.MsgTx]chainscan.Event)
+		n.tipWatcherTxs[e.BlockHash] = txs
+	}
+	txs[e.Tx] = e
+}
+
+func (n *ChainscanNotifier) drainTipWatcherTxs(blockHash *chainhash.Hash) []*dcrutil.Tx {
+	txs := n.tipWatcherTxs[*blockHash]
+	utxs := make([]*dcrutil.Tx, 0, len(txs))
+	for tx, etx := range txs {
+		utx := dcrutil.NewTx(tx)
+		utx.SetTree(etx.Tree)
+		utx.SetIndex(int(etx.TxIndex))
+		utxs = append(utxs, utx)
+	}
+
+	delete(n.tipWatcherTxs, *blockHash)
+	return utxs
+}
+
+func (n *ChainscanNotifier) handleChainEvents() {
+	defer n.wg.Done()
+
+	for {
+		var e chainscan.ChainEvent
+		select {
+		case <-n.ctx.Done():
+			return
+		case e = <-n.chainEvents:
+		}
+
+		fb := &filteredBlock{
+			hash:     e.BlockHash(),
+			height:   e.BlockHeight(),
+			prevHash: e.PrevBlockHash(),
+		}
+
+		if _, ok := e.(chainscan.BlockConnectedEvent); ok {
+			fb.connect = true
+			fb.txns = n.drainTipWatcherTxs(e.BlockHash())
+		}
+
+		select {
+		case n.chainUpdates.ChanIn() <- fb:
+		case <-n.ctx.Done():
+			return
+		}
+	}
+}
+
+// notificationDispatcher is the primary goroutine which handles client
+// notification registrations, as well as notification dispatches.
+func (n *ChainscanNotifier) notificationDispatcher() {
+out:
+	for {
+		select {
+		case cancelMsg := <-n.notificationCancels:
+			switch msg := cancelMsg.(type) {
+			case *epochCancel:
+				chainntnfs.Log.Infof("Cancelling epoch "+
+					"notification, epoch_id=%v", msg.epochID)
+
+				// First, we'll lookup the original
+				// registration in order to stop the active
+				// queue goroutine.
+				reg := n.blockEpochClients[msg.epochID]
+				reg.epochQueue.Stop()
+
+				// Next, close the cancel channel for this
+				// specific client, and wait for the client to
+				// exit.
+				close(n.blockEpochClients[msg.epochID].cancelChan)
+				n.blockEpochClients[msg.epochID].wg.Wait()
+
+				// Once the client has exited, we can then
+				// safely close the channel used to send epoch
+				// notifications, in order to notify any
+				// listeners that the intent has been
+				// canceled.
+				close(n.blockEpochClients[msg.epochID].epochChan)
+				delete(n.blockEpochClients, msg.epochID)
+			}
+
+		case registerMsg := <-n.notificationRegistry:
+			switch msg := registerMsg.(type) {
+			case *blockEpochRegistration:
+				chainntnfs.Log.Infof("New block epoch subscription")
+
+				n.blockEpochClients[msg.epochID] = msg
+
+				// If the client did not provide their best
+				// known block, then we'll immediately dispatch
+				// a notification for the current tip.
+				if msg.bestBlock == nil {
+					n.notifyBlockEpochClient(
+						msg, n.bestBlock.Height,
+						n.bestBlock.Hash,
+					)
+
+					msg.errorChan <- nil
+					continue
+				}
+
+				// Otherwise, we'll attempt to deliver the
+				// backlog of notifications from their best
+				// known block.
+				missedBlocks, err := chainntnfs.GetClientMissedBlocks(
+					n.chainConn, msg.bestBlock,
+					n.bestBlock.Height, n.chainConn.storesReorgs,
+				)
+				if err != nil {
+					msg.errorChan <- err
+					continue
+				}
+
+				for _, block := range missedBlocks {
+					n.notifyBlockEpochClient(
+						msg, block.Height, block.Hash,
+					)
+				}
+
+				msg.errorChan <- nil
+			}
+
+		case item := <-n.chainUpdates.ChanOut():
+			update := item.(*filteredBlock)
+			if update.connect {
+				if *update.prevHash != *n.bestBlock.Hash {
+					// Handle the case where the notifier
+					// missed some blocks from its chain
+					// backend
+					chainntnfs.Log.Infof("Missed blocks, " +
+						"attempting to catch up")
+					newBestBlock, missedBlocks, err :=
+						chainntnfs.HandleMissedBlocks(
+							n.chainConn,
+							n.txNotifier,
+							n.bestBlock,
+							update.height,
+							n.chainConn.storesReorgs,
+						)
+					if err != nil {
+						// Set the bestBlock here in case
+						// a catch up partially completed.
+						n.bestBlock = newBestBlock
+						chainntnfs.Log.Error(err)
+						continue
+					}
+
+					n.handleMissedBlocks(newBestBlock, missedBlocks)
+				}
+
+				if err := n.handleBlockConnected(update); err != nil {
+					chainntnfs.Log.Error(err)
+				}
+				continue
+			}
+
+			if update.height != n.bestBlock.Height {
+				chainntnfs.Log.Infof("Missed disconnected" +
+					"blocks, attempting to catch up")
+			}
+
+			newBestBlock, err := chainntnfs.RewindChain(
+				n.chainConn, n.txNotifier, n.bestBlock,
+				update.height-1,
+			)
+			if err != nil {
+				chainntnfs.Log.Errorf("Unable to rewind chain "+
+					"from height %d to height %d: %v",
+					n.bestBlock.Height, update.height-1, err)
+			}
+
+			// Set the bestBlock here in case a chain rewind
+			// partially completed.
+			n.bestBlock = newBestBlock
+
+		case <-n.quit:
+			break out
+		}
+	}
+	n.wg.Done()
+}
+
+func (n *ChainscanNotifier) handleMissedBlocks(newBestBlock chainntnfs.BlockEpoch, missed []chainntnfs.BlockEpoch) {
+	// Track the previous block hash to fill in the data.
+	prevHash := newBestBlock.Hash
+
+	for _, m := range missed {
+		bh, cfkey, filter, err := n.chainConn.c.GetCFilter(n.ctx, m.Height)
+		if err != nil {
+			return
+		}
+
+		if *bh != *m.Hash {
+			chainntnfs.Log.Warnf("Missed block hash (%s) different than "+
+				"mainchain block hash (%s)", m.Hash, bh)
+		}
+
+		e := chainscan.BlockConnectedEvent{
+			Height:   m.Height,
+			Hash:     *bh,
+			CFKey:    cfkey,
+			Filter:   filter,
+			PrevHash: *prevHash,
+		}
+		if err := n.tipWatcher.ForceRescan(n.ctx, &e); err != nil {
+			return
+		}
+
+		fb := &filteredBlock{
+			hash:     e.BlockHash(),
+			height:   e.BlockHeight(),
+			prevHash: prevHash,
+			txns:     n.drainTipWatcherTxs(e.BlockHash()),
+		}
+		prevHash = bh
+
+		n.handleBlockConnected(fb)
+	}
+}
+
+// handleBlockConnected applies a chain update for a new block. Any watched
+// transactions included this block will processed to either send notifications
+// now or after numConfirmations confs.
+func (n *ChainscanNotifier) handleBlockConnected(newBlock *filteredBlock) error {
+	// We'll then extend the txNotifier's height with the information of
+	// this new block, which will handle all of the notification logic for
+	// us.
+	newBlockHash := newBlock.hash
+	newBlockHeight := uint32(newBlock.height)
+	err := n.txNotifier.ConnectTip(
+		newBlockHash, newBlockHeight, newBlock.txns,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to connect tip: %v", err)
+	}
+
+	chainntnfs.Log.Infof("New block: height=%v, hash=%v, txs=%d", newBlockHeight,
+		newBlockHash, len(newBlock.txns))
+
+	// Now that we've guaranteed the new block extends the txNotifier's
+	// current tip, we'll proceed to dispatch notifications to all of our
+	// registered clients whom have had notifications fulfilled. Before
+	// doing so, we'll make sure update our in memory state in order to
+	// satisfy any client requests based upon the new block.
+	n.bestBlock.Hash = newBlockHash
+	n.bestBlock.Height = int32(newBlockHeight)
+
+	n.notifyBlockEpochs(int32(newBlockHeight), newBlockHash)
+	return n.txNotifier.NotifyHeight(newBlockHeight)
+}
+
+// notifyBlockEpochs notifies all registered block epoch clients of the newly
+// connected block to the main chain.
+func (n *ChainscanNotifier) notifyBlockEpochs(newHeight int32, newHash *chainhash.Hash) {
+	for _, client := range n.blockEpochClients {
+		n.notifyBlockEpochClient(client, newHeight, newHash)
+	}
+}
+
+// notifyBlockEpochClient sends a registered block epoch client a notification
+// about a specific block.
+func (n *ChainscanNotifier) notifyBlockEpochClient(epochClient *blockEpochRegistration,
+	height int32, hash *chainhash.Hash) {
+
+	epoch := &chainntnfs.BlockEpoch{
+		Height: height,
+		Hash:   hash,
+	}
+
+	select {
+	case epochClient.epochQueue.ChanIn() <- epoch:
+	case <-epochClient.cancelChan:
+	case <-n.quit:
+	}
+}
+
+// RegisterSpendNtfn registers an intent to be notified once the target
+// outpoint/output script has been spent by a transaction on-chain. When
+// intending to be notified of the spend of an output script, a nil outpoint
+// must be used. The heightHint should represent the earliest height in the
+// chain of the transaction that spent the outpoint/output script.
+//
+// Once a spend of has been detected, the details of the spending event will be
+// sent across the 'Spend' channel.
+func (n *ChainscanNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
+	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
+
+	// Register the conf notification with the TxNotifier. A non-nil value
+	// for `dispatch` will be returned if we are required to perform a
+	// manual scan for the confirmation. Otherwise the notifier will begin
+	// watching at tip for the transaction to confirm.
+	ntfn, err := n.txNotifier.RegisterSpend(outpoint, pkScript, heightHint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Normalize to zero outpoint so we don't trigger panics.
+	if outpoint == nil {
+		outpoint = &chainntnfs.ZeroOutPoint
+	}
+
+	// Set the TipWatcher to scan for spends of this output.
+	var tipTarget, histTarget chainscan.Target
+	scriptVersion := uint16(0)
+	switch {
+	case *outpoint == chainntnfs.ZeroOutPoint:
+		tipTarget = chainscan.SpentScript(scriptVersion, pkScript)
+		histTarget = chainscan.SpentScript(scriptVersion, pkScript)
+	default:
+		tipTarget = chainscan.SpentOutPoint(*outpoint, scriptVersion, pkScript)
+		histTarget = chainscan.SpentOutPoint(*outpoint, scriptVersion, pkScript)
+	}
+
+	startHeightChan := make(chan int32)
+
+	// TODO: handle cancelling this target after it is found and the
+	// txnotifier's reorgSafetyLimit has been reached.
+	n.tipWatcher.Find(
+		tipTarget,
+		chainscan.WithFoundCallback(n.foundAtTip),
+		chainscan.WithStartWatchHeightChan(startHeightChan),
+		// TODO: Add and verify safety of using
+		// WithStartHeight(ntfn.Height)
+	)
+
+	// Determine when the TipWatcher actually started watching for this tx.
+	var startWatchHeight int32
+	select {
+	case <-n.ctx.Done():
+		return nil, n.ctx.Err()
+	case startWatchHeight = <-startHeightChan:
+	}
+
+	// We can only exit early if the TipWatcher and the TxNotifier were in
+	// sync. Otherwise we might need to force a historical search to
+	// prevent any missed txs.
+	if ntfn.HistoricalDispatch == nil && uint32(startWatchHeight) <= ntfn.Height {
+		return ntfn.Event, nil
+	}
+
+	if ntfn.HistoricalDispatch == nil {
+		// Ignore the error since problems would have been returned by
+		// RegisterSpend().
+		spendReq, _ := chainntnfs.NewSpendRequest(outpoint, pkScript)
+
+		// The TipWatcher and txnotifier were out of sync, so even
+		// though originally a historical search was not needed, we
+		// force one to ensure there are no gaps in our search history.
+		ntfn.HistoricalDispatch = &chainntnfs.HistoricalSpendDispatch{
+			SpendRequest: spendReq,
+			StartHeight:  ntfn.Height,
+			EndHeight:    uint32(startWatchHeight),
+		}
+		chainntnfs.Log.Infof("Forcing historical search for %s between %d and %d",
+			spendReq, ntfn.HistoricalDispatch.StartHeight,
+			ntfn.HistoricalDispatch.EndHeight)
+	} else if uint32(startWatchHeight) > ntfn.HistoricalDispatch.EndHeight {
+		// We started watching after the txnotifier's currentHeight, so
+		// update the historical search to include the extra blocks.
+		chainntnfs.Log.Infof("Modifying historical search EndHeight "+
+			"for %s from %d to %d", ntfn.HistoricalDispatch.SpendRequest,
+			ntfn.HistoricalDispatch.EndHeight,
+			startWatchHeight)
+		ntfn.HistoricalDispatch.EndHeight = uint32(startWatchHeight)
+	}
+
+	// Handle a historical scan in a goroutine.
+	go func() {
+		var details *chainntnfs.SpendDetail
+		completeChan := make(chan struct{})
+		cancelChan := make(chan struct{})
+		foundCb := func(e chainscan.Event, _ chainscan.FindFunc) {
+			details = &chainntnfs.SpendDetail{
+				SpentOutPoint:     outpoint,
+				SpenderTxHash:     e.Tx.CachedTxHash(),
+				SpendingTx:        e.Tx,
+				SpenderInputIndex: uint32(e.Index),
+				SpendingHeight:    e.BlockHeight,
+			}
+			close(cancelChan)
+		}
+		hist := ntfn.HistoricalDispatch
+		n.historical.Find(
+			histTarget,
+			chainscan.WithFoundCallback(foundCb),
+			chainscan.WithCompleteChan(completeChan),
+			chainscan.WithCancelChan(cancelChan),
+			chainscan.WithStartHeight(int32(hist.StartHeight)),
+			chainscan.WithEndHeight(int32(hist.EndHeight)),
+			// TODO: force to notify during the historical only if
+			// the confirmation was approved or on the last block?
+			// This is to handle
+			// https://github.com/decred/dcrlnd/issues/69
+		)
+
+		select {
+		case <-n.quit:
+			close(cancelChan)
+			return
+		case <-completeChan:
+		case <-cancelChan:
+		}
+
+		// We will invoke UpdateConfDetails even if none were found.
+		// This allows the notifier to begin safely updating the height
+		// hint cache at tip, since any pending rescans have now
+		// completed.
+		err = n.txNotifier.UpdateSpendDetails(hist.SpendRequest, details)
+		if err != nil {
+			chainntnfs.Log.Error(err)
+		}
+	}()
+
+	return ntfn.Event, nil
+}
+
+// RegisterConfirmationsNtfn registers an intent to be notified once the target
+// txid/output script has reached numConfs confirmations on-chain. When
+// intending to be notified of the confirmation of an output script, a nil txid
+// must be used. The heightHint should represent the earliest height at which
+// the txid/output script could have been included in the chain.
+//
+// Progress on the number of confirmations left can be read from the 'Updates'
+// channel. Once it has reached all of its confirmations, a notification will be
+// sent across the 'Confirmed' channel.
+func (n *ChainscanNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
+	pkScript []byte,
+	numConfs, heightHint uint32) (*chainntnfs.ConfirmationEvent, error) {
+
+	// Register the conf notification with the TxNotifier. A non-nil value
+	// for `dispatch` will be returned if we are required to perform a
+	// manual scan for the confirmation. Otherwise the notifier will begin
+	// watching at tip for the transaction to confirm.
+	ntfn, err := n.txNotifier.RegisterConf(
+		txid, pkScript, numConfs, heightHint,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the TipWatcher to scan for this confirmation.
+	var tipTarget, histTarget chainscan.Target
+	scriptVersion := uint16(0)
+	switch {
+	case txid == nil || *txid == chainntnfs.ZeroHash:
+		tipTarget = chainscan.ConfirmedScript(scriptVersion, pkScript)
+		histTarget = chainscan.ConfirmedScript(scriptVersion, pkScript)
+	default:
+		tipTarget = chainscan.ConfirmedTransaction(*txid, scriptVersion, pkScript)
+		histTarget = chainscan.ConfirmedTransaction(*txid, scriptVersion, pkScript)
+	}
+
+	startHeightChan := make(chan int32)
+
+	// TODO: handle cancelling this target after it is found and the
+	// txnotifier's reorgSafetyLimit has been reached.
+	n.tipWatcher.Find(
+		tipTarget,
+		chainscan.WithFoundCallback(n.foundAtTip),
+		chainscan.WithStartWatchHeightChan(startHeightChan),
+		// TODO: Add and verify safety of using
+		// WithStartHeight(ntfn.Height)
+	)
+
+	// Determine when the TipWatcher actually started watching for this tx.
+	var startWatchHeight int32
+	select {
+	case <-n.ctx.Done():
+		return nil, n.ctx.Err()
+	case startWatchHeight = <-startHeightChan:
+	}
+
+	// We can only exit early if the TipWatcher and the TxNotifier were in
+	// sync. Otherwise we might need to force a historical search to
+	// prevent any missed txs.
+	if ntfn.HistoricalDispatch == nil && uint32(startWatchHeight) <= ntfn.Height {
+		return ntfn.Event, nil
+	}
+
+	if ntfn.HistoricalDispatch == nil {
+		// Ignore errors since they would've been triggered by
+		// RegisterConf() above.
+		confReq, _ := chainntnfs.NewConfRequest(txid, pkScript)
+
+		// The TipWatcher and txnotifier were out of sync, so even
+		// though originally a historical search was not needed, we
+		// force one to ensure there are no gaps in our search history.
+		ntfn.HistoricalDispatch = &chainntnfs.HistoricalConfDispatch{
+			ConfRequest: confReq,
+			StartHeight: ntfn.Height,
+			EndHeight:   uint32(startWatchHeight),
+		}
+		chainntnfs.Log.Infof("Forcing historical search for %s between %d and %d",
+			confReq, ntfn.HistoricalDispatch.StartHeight,
+			ntfn.HistoricalDispatch.EndHeight)
+	} else if uint32(startWatchHeight) > ntfn.HistoricalDispatch.EndHeight {
+		// We started watching after the txnotifier's currentHeight, so
+		// update the historical search to include the extra blocks.
+		chainntnfs.Log.Infof("Modifying historical search EndHeight "+
+			"for %s from %d to %d", ntfn.HistoricalDispatch.ConfRequest,
+			ntfn.HistoricalDispatch.EndHeight,
+			startWatchHeight)
+		ntfn.HistoricalDispatch.EndHeight = uint32(startWatchHeight)
+	}
+
+	// Handle a historical scan in a goroutine.
+	go func() {
+		var txconf *chainntnfs.TxConfirmation
+		completeChan := make(chan struct{})
+		cancelChan := make(chan struct{})
+		foundCb := func(e chainscan.Event, _ chainscan.FindFunc) {
+			txconf = &chainntnfs.TxConfirmation{
+				Tx:          e.Tx,
+				BlockHash:   &e.BlockHash,
+				BlockHeight: uint32(e.BlockHeight),
+				TxIndex:     uint32(e.TxIndex),
+			}
+			close(cancelChan)
+		}
+		hist := ntfn.HistoricalDispatch
+		n.historical.Find(
+			histTarget,
+			chainscan.WithFoundCallback(foundCb),
+			chainscan.WithCompleteChan(completeChan),
+			chainscan.WithCancelChan(cancelChan),
+			chainscan.WithStartHeight(int32(hist.StartHeight)),
+			chainscan.WithEndHeight(int32(hist.EndHeight)),
+			// TODO: force to notify during the historical only if
+			// the confirmation was approved or on the last block?
+			// This is to handle
+			// https://github.com/decred/dcrlnd/issues/69
+		)
+
+		select {
+		case <-n.quit:
+			close(cancelChan)
+			return
+		case <-cancelChan:
+		case <-completeChan:
+		}
+
+		// We will invoke UpdateConfDetails even if none were found.
+		// This allows the notifier to begin safely updating the height
+		// hint cache at tip, since any pending rescans have now
+		// completed.
+		err := n.txNotifier.UpdateConfDetails(
+			hist.ConfRequest, txconf,
+		)
+		if err != nil {
+			chainntnfs.Log.Error(err)
+		}
+	}()
+
+	return ntfn.Event, nil
+}
+
+// blockEpochRegistration represents a client's intent to receive a
+// notification with each newly connected block.
+type blockEpochRegistration struct {
+	epochID uint64
+
+	epochChan chan *chainntnfs.BlockEpoch
+
+	epochQueue *queue.ConcurrentQueue
+
+	bestBlock *chainntnfs.BlockEpoch
+
+	errorChan chan error
+
+	cancelChan chan struct{}
+
+	wg sync.WaitGroup
+}
+
+// epochCancel is a message sent to the ChainscanNotifier when a client wishes to
+// cancel an outstanding epoch notification that has yet to be dispatched.
+type epochCancel struct {
+	epochID uint64
+}
+
+// RegisterBlockEpochNtfn returns a BlockEpochEvent which subscribes the
+// caller to receive notifications, of each new block connected to the main
+// chain. Clients have the option of passing in their best known block, which
+// the notifier uses to check if they are behind on blocks and catch them up.
+// If they do not provide one, then a notification will be dispatched
+// immediately for the current tip of the chain upon a successful registration.
+func (n *ChainscanNotifier) RegisterBlockEpochNtfn(
+	bestBlock *chainntnfs.BlockEpoch) (*chainntnfs.BlockEpochEvent, error) {
+
+	reg := &blockEpochRegistration{
+		epochQueue: queue.NewConcurrentQueue(20),
+		epochChan:  make(chan *chainntnfs.BlockEpoch, 20),
+		cancelChan: make(chan struct{}),
+		epochID:    atomic.AddUint64(&n.epochClientCounter, 1),
+		bestBlock:  bestBlock,
+		errorChan:  make(chan error, 1),
+	}
+
+	reg.epochQueue.Start()
+
+	// Before we send the request to the main goroutine, we'll launch a new
+	// goroutine to proxy items added to our queue to the client itself.
+	// This ensures that all notifications are received *in order*.
+	reg.wg.Add(1)
+	go func() {
+		defer reg.wg.Done()
+
+		for {
+			select {
+			case ntfn := <-reg.epochQueue.ChanOut():
+				blockNtfn := ntfn.(*chainntnfs.BlockEpoch)
+				select {
+				case reg.epochChan <- blockNtfn:
+
+				case <-reg.cancelChan:
+					return
+
+				case <-n.quit:
+					return
+				}
+
+			case <-reg.cancelChan:
+				return
+
+			case <-n.quit:
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-n.quit:
+		// As we're exiting before the registration could be sent,
+		// we'll stop the queue now ourselves.
+		reg.epochQueue.Stop()
+
+		return nil, errors.New("chainntnfs: system interrupt while " +
+			"attempting to register for block epoch notification")
+	case n.notificationRegistry <- reg:
+		return &chainntnfs.BlockEpochEvent{
+			Epochs: reg.epochChan,
+			Cancel: func() {
+				cancel := &epochCancel{
+					epochID: reg.epochID,
+				}
+
+				// Submit epoch cancellation to notification dispatcher.
+				select {
+				case n.notificationCancels <- cancel:
+					// Cancellation is being handled, drain
+					// the epoch channel until it is closed
+					// before yielding to caller.
+					for {
+						select {
+						case _, ok := <-reg.epochChan:
+							if !ok {
+								return
+							}
+						case <-n.quit:
+							return
+						}
+					}
+				case <-n.quit:
+				}
+			},
+		}, nil
+	}
+}

--- a/chainntnfs/chainscannotify/csnotify_dev.go
+++ b/chainntnfs/chainscannotify/csnotify_dev.go
@@ -1,0 +1,82 @@
+// +build dev
+
+package csnotify
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrlnd/chainntnfs"
+)
+
+// TODO(decred): Determine if the generateBlocks is needed.
+//
+// UnsafeStart starts the notifier with a specified best height and optional
+// best hash. Its bestBlock and txNotifier are initialized with bestHeight and
+// optionally bestHash. The parameter generateBlocks is necessary for the
+// dcrd notifier to ensure we drain all notifications up to syncHeight,
+// since if they are generated ahead of UnsafeStart the chainConn may start up
+// with an outdated best block and miss sending ntfns. Used for testing.
+func (n *ChainscanNotifier) UnsafeStart(bestHeight int64, bestHash *chainhash.Hash,
+	syncHeight int64, generateBlocks func() error) error {
+
+	n.txNotifier = chainntnfs.NewTxNotifier(
+		uint32(bestHeight), chainntnfs.ReorgSafetyLimit,
+		n.confirmHintCache, n.spendHintCache, n.chainParams,
+	)
+
+	runAndLogOnError(n.ctx, n.chainConn.c.Run, "chainConn")
+	runAndLogOnError(n.ctx, n.tipWatcher.Run, "tipWatcher")
+	runAndLogOnError(n.ctx, n.historical.Run, "historical")
+
+	n.chainEvents = n.tipWatcher.ChainEvents(n.ctx)
+	n.chainUpdates.Start()
+
+	n.wg.Add(1)
+	go n.handleChainEvents()
+
+	if generateBlocks != nil {
+		// Ensure no block notifications are pending when we start the
+		// notification dispatcher goroutine.
+
+		// First generate the blocks, then drain the notifications
+		// for the generated blocks.
+		if err := generateBlocks(); err != nil {
+			return err
+		}
+
+		timeout := time.After(60 * time.Second)
+	loop:
+		for {
+			select {
+			case ntfn := <-n.chainUpdates.ChanOut():
+				lastReceivedNtfn := ntfn.(*filteredBlock)
+				if int64(lastReceivedNtfn.height) >= syncHeight {
+					break loop
+				}
+			case <-timeout:
+				return fmt.Errorf("unable to catch up to height %d",
+					syncHeight)
+			}
+		}
+	}
+
+	// Run notificationDispatcher after setting the notifier's best block
+	// to avoid a race condition.
+	n.bestBlock = chainntnfs.BlockEpoch{
+		Height: int32(bestHeight), Hash: bestHash,
+	}
+	if bestHash == nil {
+		hash, err := n.chainConn.GetBlockHash(int64(bestHeight))
+		if err != nil {
+			return err
+		}
+		n.bestBlock.Hash = hash
+	}
+
+	n.wg.Add(1)
+	go n.notificationDispatcher()
+
+	return nil
+}

--- a/chainntnfs/dcrdnotify/dcrd_test.go
+++ b/chainntnfs/dcrdnotify/dcrd_test.go
@@ -264,7 +264,7 @@ func TestInneficientRescan(t *testing.T) {
 
 	// Create an output and subsequently spend it.
 	outpoint, txout, privKey := chainntnfs.CreateSpendableOutput(
-		t, harness,
+		t, harness, nil,
 	)
 	spenderTx := chainntnfs.CreateSpendTx(
 		t, outpoint, txout, privKey,

--- a/chainntnfs/dcrwnotify/dcrw.go
+++ b/chainntnfs/dcrwnotify/dcrw.go
@@ -1,0 +1,69 @@
+package dcrwnotify
+
+import (
+	"context"
+
+	"decred.org/dcrwallet/wallet"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/chaincfg/v2"
+	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrlnd/chainntnfs"
+	csnotify "github.com/decred/dcrlnd/chainntnfs/chainscannotify"
+	"github.com/decred/dcrlnd/chainscan/csdrivers"
+)
+
+type DcrwChainSource struct {
+	*csdrivers.DcrwalletCSDriver
+	w *wallet.Wallet
+}
+
+func (s *DcrwChainSource) GetBlockHash(ctx context.Context, height int32) (*chainhash.Hash, error) {
+	id := wallet.NewBlockIdentifierFromHeight(height)
+	b, err := s.w.BlockInfo(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &b.Hash, err
+}
+
+func (s *DcrwChainSource) GetBlockHeader(ctx context.Context, hash *chainhash.Hash) (*wire.BlockHeader, error) {
+	id := wallet.NewBlockIdentifierFromHash(hash)
+	b, err := s.w.BlockInfo(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	var header wire.BlockHeader
+	err = header.FromBytes(b.Header)
+	if err != nil {
+		return nil, err
+	}
+
+	return &header, err
+}
+
+func (s *DcrwChainSource) StoresReorgedHeaders() bool {
+	return true
+}
+
+func NewDcrwChainSource(w *wallet.Wallet) *DcrwChainSource {
+	cs := csdrivers.NewDcrwalletCSDriver(w)
+	return &DcrwChainSource{
+		w:                 w,
+		DcrwalletCSDriver: cs,
+	}
+}
+
+var _ csnotify.ChainSource = (*DcrwChainSource)(nil)
+
+// New returns a new DcrdNotifier instance. This function assumes the dcrd node
+// detailed in the passed configuration is already running, and willing to
+// accept new websockets clients.
+func New(w *wallet.Wallet, chainParams *chaincfg.Params,
+	spendHintCache chainntnfs.SpendHintCache,
+	confirmHintCache chainntnfs.ConfirmHintCache) (*csnotify.ChainscanNotifier, error) {
+
+	src := NewDcrwChainSource(w)
+	return csnotify.New(src, chainParams, spendHintCache, confirmHintCache)
+}

--- a/chainntnfs/dcrwnotify/driver.go
+++ b/chainntnfs/dcrwnotify/driver.go
@@ -1,0 +1,66 @@
+package dcrwnotify
+
+import (
+	"errors"
+	"fmt"
+
+	"decred.org/dcrwallet/wallet"
+	"github.com/decred/dcrd/chaincfg/v2"
+	"github.com/decred/dcrlnd/chainntnfs"
+)
+
+const (
+	// notifierType uniquely identifies this concrete implementation of the
+	// ChainNotifier interface.
+	notifierType = "dcrw"
+)
+
+// createNewNotifier creates a new instance of the ChainNotifier interface
+// implemented by DcrdNotifier.
+func createNewNotifier(args ...interface{}) (chainntnfs.ChainNotifier, error) {
+	if len(args) != 4 {
+		return nil, fmt.Errorf("incorrect number of arguments to "+
+			".New(...), expected 4, instead passed %v", len(args))
+	}
+
+	w, ok := args[0].(*wallet.Wallet)
+	if !ok {
+		return nil, errors.New("first argument to dcrdnotifier.New " +
+			"is incorrect, expected a *rpcclient.ConnConfig")
+	}
+
+	chainParams, ok := args[1].(*chaincfg.Params)
+	if !ok {
+		return nil, errors.New("second argument to dcrdnotifier.New " +
+			"is incorrect, expected a *chaincfg.Params")
+	}
+
+	spendHintCache, ok := args[2].(chainntnfs.SpendHintCache)
+	if !ok {
+		return nil, errors.New("third argument to dcrdnotifier.New " +
+			"is incorrect, expected a chainntnfs.SpendHintCache")
+	}
+
+	confirmHintCache, ok := args[3].(chainntnfs.ConfirmHintCache)
+	if !ok {
+		return nil, errors.New("third argument to dcrdnotifier.New " +
+			"is incorrect, expected a chainntnfs.ConfirmHintCache")
+	}
+
+	return New(w, chainParams, spendHintCache, confirmHintCache)
+}
+
+// init registers a driver for the DcrdNotifier concrete implementation of the
+// chainntnfs.ChainNotifier interface.
+func init() {
+	// Register the driver.
+	notifier := &chainntnfs.NotifierDriver{
+		NotifierType: notifierType,
+		New:          createNewNotifier,
+	}
+
+	if err := chainntnfs.RegisterNotifier(notifier); err != nil {
+		panic(fmt.Sprintf("failed to register notifier driver '%s': %v",
+			notifierType, err))
+	}
+}

--- a/chainntnfs/interface_test.go
+++ b/chainntnfs/interface_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrlnd/chainntnfs"
 	"github.com/decred/dcrlnd/chainntnfs/dcrdnotify"
+	"github.com/decred/dcrlnd/chainntnfs/dcrwnotify"
+	"github.com/decred/dcrlnd/chainntnfs/remotedcrwnotify"
 	"github.com/decred/dcrlnd/channeldb"
 	"github.com/decred/dcrlnd/compat"
 	"github.com/decred/dcrlnd/internal/testutils"
@@ -1980,6 +1982,27 @@ func TestInterfaces(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error initializing dcrd notifier: %v", err)
 			}
+
+		case "dcrw":
+			w, teardown := testutils.NewSyncingTestWallet(t, &backend)
+			notifier, err = dcrwnotify.New(
+				w, compat.Params3to2(chainntnfs.NetParams), hintCache, hintCache,
+			)
+			if err != nil {
+				t.Fatalf("error initializing dcrw notifier: %v", err)
+			}
+			tearDownNotifier = teardown
+
+		case "remotedcrw":
+			c, teardown := testutils.NewTestRemoteDcrwallet(t, &backend)
+			notifier, err = remotedcrwnotify.New(
+				c, compat.Params3to2(chainntnfs.NetParams), hintCache, hintCache,
+			)
+			if err != nil {
+				t.Fatalf("error initializing dcrw notifier: %v", err)
+			}
+			tearDownNotifier = teardown
+
 		default:
 			t.Fatalf("unknown notifier type: %v", notifierType)
 		}
@@ -2010,7 +2033,6 @@ func TestInterfaces(t *testing.T) {
 		notifierType := notifierDriver.NotifierType
 
 		success := t.Run(notifierType, func(t *testing.T) {
-
 			miner, vw, tearDownMiner := newMiner(t, notifierType)
 			defer tearDownMiner()
 

--- a/chainntnfs/remotedcrwnotify/driver.go
+++ b/chainntnfs/remotedcrwnotify/driver.go
@@ -1,0 +1,66 @@
+package remotedcrwnotify
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/decred/dcrd/chaincfg/v2"
+	"github.com/decred/dcrlnd/chainntnfs"
+	"google.golang.org/grpc"
+)
+
+const (
+	// notifierType uniquely identifies this concrete implementation of the
+	// ChainNotifier interface.
+	notifierType = "remotedcrw"
+)
+
+// createNewNotifier creates a new instance of the ChainNotifier interface
+// implemented by DcrdNotifier.
+func createNewNotifier(args ...interface{}) (chainntnfs.ChainNotifier, error) {
+	if len(args) != 4 {
+		return nil, fmt.Errorf("incorrect number of arguments to "+
+			".New(...), expected 4, instead passed %v", len(args))
+	}
+
+	conn, ok := args[0].(*grpc.ClientConn)
+	if !ok {
+		return nil, errors.New("first argument to dcrdnotifier.New " +
+			"is incorrect, expected a *grpc.ClientConn")
+	}
+
+	chainParams, ok := args[1].(*chaincfg.Params)
+	if !ok {
+		return nil, errors.New("second argument to dcrdnotifier.New " +
+			"is incorrect, expected a *chaincfg.Params")
+	}
+
+	spendHintCache, ok := args[2].(chainntnfs.SpendHintCache)
+	if !ok {
+		return nil, errors.New("third argument to dcrdnotifier.New " +
+			"is incorrect, expected a chainntnfs.SpendHintCache")
+	}
+
+	confirmHintCache, ok := args[3].(chainntnfs.ConfirmHintCache)
+	if !ok {
+		return nil, errors.New("third argument to dcrdnotifier.New " +
+			"is incorrect, expected a chainntnfs.ConfirmHintCache")
+	}
+
+	return New(conn, chainParams, spendHintCache, confirmHintCache)
+}
+
+// init registers a driver for the DcrdNotifier concrete implementation of the
+// chainntnfs.ChainNotifier interface.
+func init() {
+	// Register the driver.
+	notifier := &chainntnfs.NotifierDriver{
+		NotifierType: notifierType,
+		New:          createNewNotifier,
+	}
+
+	if err := chainntnfs.RegisterNotifier(notifier); err != nil {
+		panic(fmt.Sprintf("failed to register notifier driver '%s': %v",
+			notifierType, err))
+	}
+}

--- a/chainntnfs/remotedcrwnotify/remotedcrw.go
+++ b/chainntnfs/remotedcrwnotify/remotedcrw.go
@@ -1,0 +1,75 @@
+package remotedcrwnotify
+
+import (
+	"context"
+
+	"decred.org/dcrwallet/rpc/walletrpc"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/chaincfg/v2"
+	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrlnd/chainntnfs"
+	csnotify "github.com/decred/dcrlnd/chainntnfs/chainscannotify"
+	"github.com/decred/dcrlnd/chainscan/csdrivers"
+	"google.golang.org/grpc"
+)
+
+type RemoteWalletChainSource struct {
+	*csdrivers.RemoteWalletCSDriver
+	wsvc walletrpc.WalletServiceClient
+}
+
+func (s *RemoteWalletChainSource) GetBlockHash(ctx context.Context, height int32) (*chainhash.Hash, error) {
+	req := &walletrpc.BlockInfoRequest{
+		BlockHeight: height,
+	}
+	resp, err := s.wsvc.BlockInfo(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return chainhash.NewHash(resp.BlockHash)
+}
+
+func (s *RemoteWalletChainSource) GetBlockHeader(ctx context.Context, hash *chainhash.Hash) (*wire.BlockHeader, error) {
+	req := &walletrpc.BlockInfoRequest{
+		BlockHash: hash[:],
+	}
+	resp, err := s.wsvc.BlockInfo(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var header wire.BlockHeader
+	err = header.FromBytes(resp.BlockHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &header, err
+}
+
+func (s *RemoteWalletChainSource) StoresReorgedHeaders() bool {
+	return true
+}
+
+func NewRemoteWalletChainSource(conn *grpc.ClientConn) *RemoteWalletChainSource {
+	wsvc := walletrpc.NewWalletServiceClient(conn)
+	nsvc := walletrpc.NewNetworkServiceClient(conn)
+	cs := csdrivers.NewRemoteWalletCSDriver(wsvc, nsvc)
+	return &RemoteWalletChainSource{
+		wsvc:                 wsvc,
+		RemoteWalletCSDriver: cs,
+	}
+}
+
+var _ csnotify.ChainSource = (*RemoteWalletChainSource)(nil)
+
+// New returns a new DcrdNotifier instance. This function assumes the dcrd node
+// detailed in the passed configuration is already running, and willing to
+// accept new websockets clients.
+func New(conn *grpc.ClientConn, chainParams *chaincfg.Params,
+	spendHintCache chainntnfs.SpendHintCache,
+	confirmHintCache chainntnfs.ConfirmHintCache) (*csnotify.ChainscanNotifier, error) {
+
+	src := NewRemoteWalletChainSource(conn)
+	return csnotify.New(src, chainParams, spendHintCache, confirmHintCache)
+}


### PR DESCRIPTION
**Rebased on top of #83**

Part of #80 

This adds implementations for the chainntnfs package that use the wallet as source of chain events.

This allows to further decouple dcrlnd from an underlying dcrd, which is a requirement for having a dcrlnd instance running in SPV mode.
