### PR TITLE
Switch to wallet-backed chain io in dcrlnd

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [1.14]
-        testsuite: ["unit-race", "itest-only", "itest-only walletimpl=remotewallet"]
+        testsuite: ["unit-race", "itest-only", "itest-only walletimpl=remotewallet", "itest-only walletimpl=embedded_dcrw"]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v1

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -15,6 +15,8 @@ import (
 	"github.com/decred/dcrd/rpcclient/v6"
 	"github.com/decred/dcrlnd/chainntnfs"
 	"github.com/decred/dcrlnd/chainntnfs/dcrdnotify"
+	"github.com/decred/dcrlnd/chainntnfs/dcrwnotify"
+	"github.com/decred/dcrlnd/chainntnfs/remotedcrwnotify"
 	"github.com/decred/dcrlnd/channeldb"
 	"github.com/decred/dcrlnd/htlcswitch"
 	"github.com/decred/dcrlnd/input"
@@ -200,7 +202,7 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 	}
 
 	switch cfg.Node {
-	case "dcrd":
+	case "dcrd", "dcrw":
 		// Otherwise, we'll be speaking directly via RPC to a node.
 		//
 		// So first we'll load dcrd's TLS cert for the RPC
@@ -252,20 +254,6 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 			DisableConnectOnNew:  true,
 			DisableAutoReconnect: false,
 		}
-		cc.chainNotifier, err = dcrdnotify.New(
-			rpcConfig, activeNetParams.Params, hintCache, hintCache,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		// Finally, we'll create an instance of the default chain view to be
-		// used within the routing layer.
-		cc.chainView, err = chainview.NewDcrdFilteredChainView(*rpcConfig)
-		if err != nil {
-			srvrLog.Errorf("unable to create chain view: %v", err)
-			return nil, err
-		}
 
 		// Verify that the provided dcrd instance exists, is reachable,
 		// it's on the correct network and has the features required
@@ -276,34 +264,59 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 			return nil, err
 		}
 
-		cc.chainIO, err = dcrwallet.NewRPCChainIO(*rpcConfig, activeNetParams.Params)
-		if err != nil {
-			return nil, err
-		}
+		// We only connect and use an underlying dcrd instance when
+		// running with an embedded wallet and in dcrd mode. Otherwise
+		// we'll use the wallet for chain operations.
+		if conn == nil && cfg.Node == "dcrd" {
+			srvrLog.Info("Using dcrd for chain operations")
 
-		// If we're not in simnet or regtest mode, then we'll attempt
-		// to use a proper fee estimator for testnet.
-		if !cfg.SimNet && !cfg.RegTest {
-			ltndLog.Infof("Initializing dcrd backed fee estimator")
-
-			// Finally, we'll re-initialize the fee estimator, as
-			// if we're using dcrd as a backend, then we can use
-			// live fee estimates, rather than a statically coded
-			// value.
-			//
-			// TODO(decred) Review if fallbackFeeRate should be higher than
-			// the default relay fee.
-			fallBackFeeRate := chainfee.AtomPerKByte(1e4)
-			cc.feeEstimator, err = chainfee.NewDcrdEstimator(
-				*rpcConfig, fallBackFeeRate,
+			cc.chainNotifier, err = dcrdnotify.New(
+				rpcConfig, activeNetParams.Params, hintCache, hintCache,
 			)
 			if err != nil {
 				return nil, err
 			}
-			if err := cc.feeEstimator.Start(); err != nil {
+
+			// Finally, we'll create an instance of the default chain view to be
+			// used within the routing layer.
+			cc.chainView, err = chainview.NewDcrdFilteredChainView(*rpcConfig)
+			if err != nil {
+				srvrLog.Errorf("unable to create chain view: %v", err)
 				return nil, err
 			}
+
+			cc.chainIO, err = dcrwallet.NewRPCChainIO(*rpcConfig, activeNetParams.Params)
+			if err != nil {
+				return nil, err
+			}
+
+			// If we're not in simnet or regtest mode, then we'll attempt
+			// to use a proper fee estimator for testnet.
+			if !cfg.SimNet && !cfg.RegTest {
+				ltndLog.Infof("Initializing dcrd backed fee estimator")
+
+				// Finally, we'll re-initialize the fee estimator, as
+				// if we're using dcrd as a backend, then we can use
+				// live fee estimates, rather than a statically coded
+				// value.
+				//
+				// TODO(decred) Review if fallbackFeeRate should be higher than
+				// the default relay fee.
+				fallBackFeeRate := chainfee.AtomPerKByte(1e4)
+				cc.feeEstimator, err = chainfee.NewDcrdEstimator(
+					*rpcConfig, fallBackFeeRate,
+				)
+				if err != nil {
+					return nil, err
+				}
+				if err := cc.feeEstimator.Start(); err != nil {
+					return nil, err
+				}
+			}
+		} else {
+			srvrLog.Info("Using underlying wallet for chain operations")
 		}
+
 	default:
 		return nil, fmt.Errorf("unknown node type: %s",
 			cfg.Node)
@@ -334,11 +347,25 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 			return nil, err
 		}
 
+		cc.chainNotifier, err = remotedcrwnotify.New(
+			conn, activeNetParams.Params, hintCache, hintCache,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		cc.chainView, err = chainview.NewRemoteWalletFilteredChainView(conn)
+		if err != nil {
+			srvrLog.Errorf("unable to create chain view: %v", err)
+			return nil, err
+		}
+
 		secretKeyRing = wc
 		cc.msgSigner = wc
 		cc.signer = wc
 		cc.wc = wc
 		cc.keyRing = wc
+		cc.chainIO = wc
 
 	default:
 		// Initialize an RPC syncer for this wallet and use it as
@@ -369,6 +396,23 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 		if err != nil {
 			fmt.Printf("unable to create wallet controller: %v\n", err)
 			return nil, err
+		}
+
+		if cfg.Node == "dcrw" {
+			cc.chainNotifier, err = dcrwnotify.New(
+				wc.InternalWallet(), activeNetParams.Params, hintCache, hintCache,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			cc.chainView, err = chainview.NewDcrwalletFilteredChainView(wc.InternalWallet())
+			if err != nil {
+				srvrLog.Errorf("unable to create chain view: %v", err)
+				return nil, err
+			}
+
+			cc.chainIO = wc
 		}
 
 		secretKeyRing = wc

--- a/config.go
+++ b/config.go
@@ -238,7 +238,7 @@ type config struct {
 	BackupFilePath     string `long:"backupfilepath" description:"The target location of the channel backup file"`
 
 	ChainDir            string           `long:"chaindir" description:"The directory to store the chain's data within."`
-	Node                string           `long:"node" description:"The blockchain interface to use." choice:"dcrd"`
+	Node                string           `long:"node" description:"The blockchain interface to use." choice:"dcrd" choice:"dcrw"`
 	TestNet3            bool             `long:"testnet" description:"Use the test network"`
 	SimNet              bool             `long:"simnet" description:"Use the simulation test network"`
 	RegTest             bool             `long:"regtest" description:"Use the regression test network"`
@@ -666,7 +666,7 @@ func loadConfig() (*config, error) {
 	}
 
 	switch cfg.Node {
-	case "dcrd":
+	case "dcrd", "dcrw":
 		err := parseRPCParams(
 			cfg.DcrdMode, decredChain, cfg.SimNet,
 			cfg.Node, funcName,

--- a/lntest/embeddedwallet-dcrd.go
+++ b/lntest/embeddedwallet-dcrd.go
@@ -1,11 +1,11 @@
-// +build remotewallet
+// +build !remotewallet,!embeddedwallet_dcrw
 
 package lntest
 
 func useRemoteWallet() bool {
-	return true
+	return false
 }
 
 func useDcrwNode() bool {
-	return true
+	return false
 }

--- a/lntest/embeddedwallet-dcrw.go
+++ b/lntest/embeddedwallet-dcrw.go
@@ -1,9 +1,9 @@
-// +build remotewallet
+// +build embeddedwallet_dcrw
 
 package lntest
 
 func useRemoteWallet() bool {
-	return true
+	return false
 }
 
 func useDcrwNode() bool {

--- a/lntest/embeddedwallet.go
+++ b/lntest/embeddedwallet.go
@@ -1,7 +1,0 @@
-// +build !remotewallet
-
-package lntest
-
-func useRemoteWallet() bool {
-	return false
-}

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -400,6 +400,7 @@ func (n *NetworkHarness) newNode(name string, extraArgs []string,
 		NetParams:    n.netParams,
 		ExtraArgs:    extraArgs,
 		RemoteWallet: useRemoteWallet(),
+		DcrwNode:     useDcrwNode(),
 	})
 	if err != nil {
 		return nil, err

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -157,6 +157,7 @@ type NodeConfig struct {
 	HasSeed      bool
 	Password     []byte
 	RemoteWallet bool
+	DcrwNode     bool
 
 	P2PPort     int
 	RPCPort     int
@@ -230,6 +231,10 @@ func (cfg NodeConfig) genArgs() []string {
 	if cfg.RemoteWallet {
 		args = append(args, fmt.Sprintf("--dcrwallet.grpchost=localhost:%d", cfg.WalletPort))
 		args = append(args, fmt.Sprintf("--dcrwallet.certpath=%s", cfg.TLSCertPath))
+	}
+
+	if cfg.DcrwNode {
+		args = append(args, "--node=dcrw")
 	}
 
 	if !cfg.HasSeed {

--- a/lnwallet/dcrwallet/dcrwchainio.go
+++ b/lnwallet/dcrwallet/dcrwchainio.go
@@ -1,0 +1,172 @@
+package dcrwallet
+
+import (
+	"context"
+	"time"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/wire"
+
+	"github.com/decred/dcrlnd/chainscan"
+	"github.com/decred/dcrlnd/chainscan/csdrivers"
+	"github.com/decred/dcrlnd/lnwallet"
+
+	"decred.org/dcrwallet/errors"
+	"decred.org/dcrwallet/wallet"
+)
+
+// Compile time check to ensure DcrWallet fulfills lnwallet.BlockChainIO.
+var _ lnwallet.BlockChainIO = (*DcrWallet)(nil)
+
+// GetBestBlock returns the current height and hash of the best known block
+// within the main chain.
+//
+// This method is a part of the lnwallet.BlockChainIO interface.
+func (b *DcrWallet) GetBestBlock() (*chainhash.Hash, int32, error) {
+	bh, h := b.wallet.MainChainTip(b.ctx)
+	return &bh, h, nil
+}
+
+func runAndLogOnError(ctx context.Context, f func(context.Context) error, name string) {
+	go func() {
+		err := f(ctx)
+		select {
+		case <-ctx.Done():
+			// Any errs were due to done() so, ok
+			return
+		default:
+		}
+		if err != nil {
+			dcrwLog.Errorf("Dcrwallet error while running %s: %v", name, err)
+		}
+	}()
+}
+
+// GetUtxo returns the original output referenced by the passed outpoint that
+// created the target pkScript.
+//
+// This method is a part of the lnwallet.BlockChainIO interface.
+func (b *DcrWallet) GetUtxo(op *wire.OutPoint, pkScript []byte,
+	heightHint uint32, cancel <-chan struct{}) (*wire.TxOut, error) {
+	src := csdrivers.NewDcrwalletCSDriver(b.wallet)
+	ctx, cancelCtx := context.WithCancel(b.ctx)
+	defer cancelCtx()
+
+	historical := chainscan.NewHistorical(src)
+	scriptVersion := uint16(0)
+	confirmCompleted := make(chan struct{})
+	spendCompleted := make(chan struct{})
+	var confirmOut *wire.TxOut
+	var spent *chainscan.Event
+
+	runAndLogOnError(ctx, src.Run, "GetUtxo.DcrwalletCSDriver")
+	runAndLogOnError(ctx, historical.Run, "GetUtxo.Historical")
+
+	dcrwLog.Debugf("GetUtxo looking for %s start at %d", op, heightHint)
+
+	foundSpend := func(e chainscan.Event, _ chainscan.FindFunc) {
+		dcrwLog.Debugf("Found spend of %s on block %d (%s) for GetUtxo",
+			op, e.BlockHeight, e.BlockHash)
+		spent = &e
+	}
+
+	foundConfirm := func(e chainscan.Event, findExtra chainscan.FindFunc) {
+		// Found confirmation of the outpoint. Try to find someone
+		// spending it.
+		confirmOut = e.Tx.TxOut[e.Index]
+		dcrwLog.Debugf("Found confirmation of %s on block %d (%s) for GetUtxo",
+			op, e.BlockHeight, e.BlockHash)
+		findExtra(
+			chainscan.SpentOutPoint(*op, scriptVersion, pkScript),
+			chainscan.WithStartHeight(e.BlockHeight),
+			chainscan.WithFoundCallback(foundSpend),
+			chainscan.WithCancelChan(cancel),
+			chainscan.WithCompleteChan(spendCompleted),
+		)
+	}
+
+	// First search for the confirmation of the given script, then for its
+	// spending.
+	historical.Find(
+		chainscan.ConfirmedOutPoint(*op, scriptVersion, pkScript),
+		chainscan.WithStartHeight(int32(heightHint)),
+		chainscan.WithCancelChan(cancel),
+		chainscan.WithFoundCallback(foundConfirm),
+		chainscan.WithCompleteChan(confirmCompleted),
+	)
+
+	for confirmCompleted != nil && spendCompleted != nil {
+		select {
+		case <-cancel:
+			return nil, errors.New("GetUtxo cancelled by caller")
+		case <-ctx.Done():
+			return nil, errors.New("wallet shutting down")
+		case <-confirmCompleted:
+			confirmCompleted = nil
+		case <-spendCompleted:
+			spendCompleted = nil
+		}
+	}
+
+	switch {
+	case spent != nil:
+		return nil, errors.Errorf("output %s spent by %s:%d", op,
+			spent.Tx.CachedTxHash(), spent.Index)
+	case confirmOut != nil:
+		return confirmOut, nil
+	default:
+		return nil, errors.Errorf("output %s not found during chain scan", op)
+	}
+}
+
+// GetBlock returns a raw block from the server given its hash.
+//
+// This method is a part of the lnwallet.BlockChainIO interface.
+func (b *DcrWallet) GetBlock(blockHash *chainhash.Hash) (*wire.MsgBlock, error) {
+	// TODO: unify with the driver on chainscan.
+	ctx := b.ctx
+
+getblock:
+	for {
+		// Keep trying to get the network backend until the context is
+		// canceled.
+		n, err := b.wallet.NetworkBackend()
+		if errors.Is(err, errors.NoPeers) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Second):
+				continue getblock
+			}
+		}
+
+		blocks, err := n.Blocks(ctx, []*chainhash.Hash{blockHash})
+		if len(blocks) > 0 && err == nil {
+			return blocks[0], nil
+		}
+
+		// The syncer might have failed due to any number of reasons,
+		// but it's likely it will come back online shortly. So wait
+		// until we can try again.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+
+}
+
+// GetBlockHash returns the hash of the block in the best blockchain at the
+// given height.
+//
+// This method is a part of the lnwallet.BlockChainIO interface.
+func (b *DcrWallet) GetBlockHash(blockHeight int64) (*chainhash.Hash, error) {
+	id := wallet.NewBlockIdentifierFromHeight(int32(blockHeight))
+	bl, err := b.wallet.BlockInfo(b.ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bl.Hash, err
+}

--- a/lnwallet/dcrwallet/wallet.go
+++ b/lnwallet/dcrwallet/wallet.go
@@ -74,6 +74,9 @@ type DcrWallet struct {
 
 	syncer WalletSyncer
 
+	ctx       context.Context
+	cancelCtx func()
+
 	*walletKeyRing
 }
 
@@ -121,6 +124,8 @@ func New(cfg Config) (*DcrWallet, error) {
 		}
 	}
 
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
 	return &DcrWallet{
 		cfg:                &cfg,
 		wallet:             wallet,
@@ -129,6 +134,8 @@ func New(cfg Config) (*DcrWallet, error) {
 		syncedChan:         make(chan struct{}),
 		atomicWalletSynced: syncStatusUnsynced,
 		netParams:          cfg.NetParams,
+		ctx:                ctx,
+		cancelCtx:          cancelCtx,
 	}, nil
 }
 
@@ -177,6 +184,7 @@ func (b *DcrWallet) Start() error {
 // This is a part of the WalletController interface.
 func (b *DcrWallet) Stop() error {
 	dcrwLog.Debug("Requesting wallet shutdown")
+	b.cancelCtx()
 	b.syncer.stop()
 	b.syncer.waitForShutdown()
 
@@ -766,12 +774,14 @@ func (b *DcrWallet) IsSynced() (bool, int64, error) {
 	// TODO(decred) Check if the wallet is still syncing.  This is
 	// currently done by checking the associated chainIO but ideally the
 	// wallet should return the height it's attempting to sync to.
-	ioHash, _, err := b.cfg.ChainIO.GetBestBlock()
-	if err != nil {
-		return false, 0, fmt.Errorf("chainIO.GetBestBlock error: %v", err)
-	}
-	if !bytes.Equal(walletBestHash[:], ioHash[:]) {
-		return false, walletBestHeader.Timestamp.Unix(), nil
+	if b.cfg.ChainIO != nil {
+		ioHash, _, err := b.cfg.ChainIO.GetBestBlock()
+		if err != nil {
+			return false, 0, err
+		}
+		if !bytes.Equal(walletBestHash[:], ioHash[:]) {
+			return false, walletBestHeader.Timestamp.Unix(), nil
+		}
 	}
 
 	// If the timestamp on the best header is more than 2 hours in the

--- a/lnwallet/remotedcrwallet/remotedcrwchainio.go
+++ b/lnwallet/remotedcrwallet/remotedcrwchainio.go
@@ -1,0 +1,188 @@
+package remotedcrwallet
+
+import (
+	"context"
+	"time"
+
+	"decred.org/dcrwallet/errors"
+	"decred.org/dcrwallet/rpc/walletrpc"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/wire"
+
+	"github.com/decred/dcrlnd/chainscan"
+	"github.com/decred/dcrlnd/chainscan/csdrivers"
+	"github.com/decred/dcrlnd/lnwallet"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Compile time check to ensure DcrWallet fulfills lnwallet.BlockChainIO.
+var _ lnwallet.BlockChainIO = (*DcrWallet)(nil)
+
+func runAndLogOnError(ctx context.Context, f func(context.Context) error, name string) {
+	go func() {
+		err := f(ctx)
+		select {
+		case <-ctx.Done():
+			// Any errs were due to done() so, ok
+			return
+		default:
+		}
+		if err != nil {
+			dcrwLog.Errorf("RemoteWallet error while running %s: %v", name, err)
+		}
+	}()
+}
+
+// GetBestBlock returns the current height and hash of the best known block
+// within the main chain.
+//
+// This method is a part of the lnwallet.BlockChainIO interface.
+func (b *DcrWallet) GetBestBlock() (*chainhash.Hash, int32, error) {
+	resp, err := b.wallet.BestBlock(b.ctx, &walletrpc.BestBlockRequest{})
+	if err != nil {
+		return nil, 0, err
+	}
+	bh, err := chainhash.NewHash(resp.Hash)
+	if err != nil {
+		return nil, 0, err
+	}
+	return bh, int32(resp.Height), nil
+}
+
+// GetUtxo returns the original output referenced by the passed outpoint that
+// create the target pkScript.
+//
+// This method is a part of the lnwallet.BlockChainIO interface.
+func (b *DcrWallet) GetUtxo(op *wire.OutPoint, pkScript []byte,
+	heightHint uint32, cancel <-chan struct{}) (*wire.TxOut, error) {
+	// FIXME: unify with the dcrwallet driver.
+	src := csdrivers.NewRemoteWalletCSDriver(b.wallet, b.network)
+	ctx, cancelCtx := context.WithCancel(b.ctx)
+	defer cancelCtx()
+
+	historical := chainscan.NewHistorical(src)
+	scriptVersion := uint16(0)
+	confirmCompleted := make(chan struct{})
+	spendCompleted := make(chan struct{})
+	var confirmOut *wire.TxOut
+	var spent *chainscan.Event
+
+	runAndLogOnError(ctx, src.Run, "GetUtxo.RemoteWalletCSDriver")
+	runAndLogOnError(ctx, historical.Run, "GetUtxo.Historical")
+
+	dcrwLog.Debugf("GetUtxo looking for %s start at %d", op, heightHint)
+
+	foundSpend := func(e chainscan.Event, _ chainscan.FindFunc) {
+		dcrwLog.Debugf("Found spend of %s on block %d (%s) for GetUtxo",
+			op, e.BlockHeight, e.BlockHash)
+		spent = &e
+	}
+
+	foundConfirm := func(e chainscan.Event, findExtra chainscan.FindFunc) {
+		// Found confirmation of the outpoint. Try to find someone
+		// spending it.
+		confirmOut = e.Tx.TxOut[e.Index]
+		dcrwLog.Debugf("Found confirmation of %s on block %d (%s) for GetUtxo",
+			op, e.BlockHeight, e.BlockHash)
+		findExtra(
+			chainscan.SpentOutPoint(*op, scriptVersion, pkScript),
+			chainscan.WithStartHeight(e.BlockHeight),
+			chainscan.WithFoundCallback(foundSpend),
+			chainscan.WithCancelChan(cancel),
+			chainscan.WithCompleteChan(spendCompleted),
+		)
+	}
+
+	// First search for the confirmation of the given script, then for its
+	// spending.
+	historical.Find(
+		chainscan.ConfirmedOutPoint(*op, scriptVersion, pkScript),
+		chainscan.WithStartHeight(int32(heightHint)),
+		chainscan.WithCancelChan(cancel),
+		chainscan.WithFoundCallback(foundConfirm),
+		chainscan.WithCompleteChan(confirmCompleted),
+	)
+
+	for confirmCompleted != nil && spendCompleted != nil {
+		select {
+		case <-cancel:
+			return nil, errors.New("GetUtxo cancelled by caller")
+		case <-ctx.Done():
+			return nil, errors.New("wallet shutting down")
+		case <-confirmCompleted:
+			confirmCompleted = nil
+		case <-spendCompleted:
+			spendCompleted = nil
+		}
+	}
+
+	switch {
+	case spent != nil:
+		return nil, errors.Errorf("output %s spent by %s:%d", op,
+			spent.Tx.CachedTxHash(), spent.Index)
+	case confirmOut != nil:
+		return confirmOut, nil
+	default:
+		return nil, errors.Errorf("output %s not found during chain scan", op)
+	}
+}
+
+// GetBlock returns a raw block from the server given its hash.
+//
+// This method is a part of the lnwallet.BlockChainIO interface.
+func (b *DcrWallet) GetBlock(blockHash *chainhash.Hash) (*wire.MsgBlock, error) {
+	// TODO: unify with the driver on chainscan.
+	var (
+		resp *walletrpc.GetRawBlockResponse
+		err  error
+	)
+
+	req := &walletrpc.GetRawBlockRequest{
+		BlockHash: blockHash[:],
+	}
+
+	// If the response error code is 'Unavailable' it means the wallet
+	// isn't connected to any peers while in SPV mode. In that case, wait a
+	// bit and try again.
+	for stop := false; !stop; {
+		resp, err = b.network.GetRawBlock(b.ctx, req)
+		switch {
+		case status.Code(err) == codes.Unavailable:
+			dcrwLog.Warnf("Network unavailable from wallet; will try again in 5 seconds")
+			select {
+			case <-b.ctx.Done():
+				return nil, b.ctx.Err()
+			case <-time.After(5 * time.Second):
+			}
+		case err != nil:
+			return nil, err
+		default:
+			stop = true
+		}
+	}
+
+	bl := &wire.MsgBlock{}
+	err = bl.FromBytes(resp.Block)
+	if err != nil {
+		return nil, err
+	}
+
+	return bl, nil
+}
+
+// GetBlockHash returns the hash of the block in the best blockchain at the
+// given height.
+//
+// This method is a part of the lnwallet.BlockChainIO interface.
+func (b *DcrWallet) GetBlockHash(blockHeight int64) (*chainhash.Hash, error) {
+	req := &walletrpc.BlockInfoRequest{
+		BlockHeight: int32(blockHeight),
+	}
+	resp, err := b.wallet.BlockInfo(b.ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return chainhash.NewHash(resp.BlockHash)
+}

--- a/lnwallet/remotedcrwallet/wallet.go
+++ b/lnwallet/remotedcrwallet/wallet.go
@@ -62,7 +62,10 @@ type DcrWallet struct {
 	// doesn't provide an entpoint to control this directly in the wallet.
 	lockedOutpoints map[wire.OutPoint]struct{}
 
-	wallet pb.WalletServiceClient
+	wallet    pb.WalletServiceClient
+	network   pb.NetworkServiceClient
+	ctx       context.Context
+	cancelCtx func()
 }
 
 // A compile time check to ensure that DcrWallet implements the
@@ -87,6 +90,7 @@ func New(cfg Config) (*DcrWallet, error) {
 	// the default account.
 	ctxb := context.Background()
 	wallet := pb.NewWalletServiceClient(cfg.Conn)
+	network := pb.NewNetworkServiceClient(cfg.Conn)
 	req := &pb.GetAccountExtendedPrivKeyRequest{
 		AccountNumber: uint32(cfg.AccountNumber),
 		Passphrase:    cfg.PrivatePass,
@@ -129,6 +133,7 @@ func New(cfg Config) (*DcrWallet, error) {
 			"previously stored account ID: %v", cfg.AccountNumber, err)
 	}
 
+	ctx, cancelCtx := context.WithCancel(ctxb)
 	dcrw := &DcrWallet{
 		account:         uint32(cfg.AccountNumber),
 		syncedChan:      make(chan struct{}),
@@ -137,9 +142,12 @@ func New(cfg Config) (*DcrWallet, error) {
 		cfg:             cfg,
 		conn:            cfg.Conn,
 		wallet:          wallet,
+		network:         network,
 		branchExtXPriv:  branchExtXPriv,
 		branchIntXPriv:  branchIntXPriv,
 		lockedOutpoints: make(map[wire.OutPoint]struct{}),
+		ctx:             ctx,
+		cancelCtx:       cancelCtx,
 	}
 
 	// Finally, create the keyring using the conventions for remote
@@ -175,6 +183,7 @@ func (b *DcrWallet) Start() error {
 //
 // This is a part of the WalletController interface.
 func (b *DcrWallet) Stop() error {
+	b.cancelCtx()
 	return b.conn.Close()
 }
 
@@ -917,12 +926,14 @@ func (b *DcrWallet) IsSynced() (bool, int64, error) {
 	// TODO(decred) Check if the wallet is still syncing.  This is
 	// currently done by checking the associated chainIO but ideally the
 	// wallet should return the height it's attempting to sync to.
-	ioHash, _, err := b.cfg.ChainIO.GetBestBlock()
-	if err != nil {
-		return false, 0, err
-	}
-	if !bytes.Equal(walletBestHash, ioHash[:]) {
-		return false, headerTS.Unix(), nil
+	if b.cfg.ChainIO != nil {
+		ioHash, _, err := b.cfg.ChainIO.GetBestBlock()
+		if err != nil {
+			return false, 0, err
+		}
+		if !bytes.Equal(walletBestHash, ioHash[:]) {
+			return false, headerTS.Unix(), nil
+		}
 	}
 
 	// If the timestamp on the best header is more than 2 hours in the


### PR DESCRIPTION
**Rebased on top of #93**

Part of #80 

This switches the main dcrlnd package to use the recently introduced wallet-backed drivers for chain IO operations.

The net result is that chain IO operations are now fully performed by the underlying dcrwallet instance and dcrlnd no longer requires a connection to a running dcrd to perform its job.

For dcrlnd operating in remote wallet mode (such as those running from within Decrediton) the change is automatic.

For dcrlnd operating with an embedded dcrwallet, a new value for the `node` config option (`dcrw`) must be specified to use the new IO mode. Both the old `dcrd` mode and the `dcrw` mode are tested via itests running in the Github Actions CI.
