### PR TITLE
rpcserver: Check in/out total bandwidth instead of per-channel

### DIFF
--- a/lntest/itest/dcrlnd_maxio_test.go
+++ b/lntest/itest/dcrlnd_maxio_test.go
@@ -250,8 +250,6 @@ func testAddReceiveInvoiceMaxInboundAmt(net *lntest.NetworkHarness, t *harnessTe
 // various circumstances when taking into account the maximum outbound amount
 // available in directly connected channels.
 func testSendPaymentMaxOutboundAmt(net *lntest.NetworkHarness, t *harnessTest) {
-	t.Skipf("FIXME: Disabled due to ongoing upstream port work")
-
 	ctxb := context.Background()
 
 	// Create a Carol node to use in tests. All invoices will be created on
@@ -309,15 +307,14 @@ func testSendPaymentMaxOutboundAmt(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Now open a channel from Carol -> Bob.
-	ctype := commitTypeAnchors
+	ctype := commitTypeLegacy
 	chanAmt := int64(1000000)
 	pushAmt := chanAmt / 2
 	chanReserve := chanAmt / 100
 	txFee := ctype.calcStaticFee(0)
-	htlcFee := 0 // relay fee of tests is 0
 	peerHtlcFee := ctype.calcStaticFee(1) - ctype.calcStaticFee(0)
 	localAmt := chanAmt - pushAmt - int64(txFee)
-	maxPayAmt := localAmt - chanReserve - int64(htlcFee)
+	maxPayAmt := localAmt - chanReserve
 	channelParam := lntest.OpenChannelParams{
 		Amt:     dcrutil.Amount(chanAmt),
 		PushAmt: dcrutil.Amount(pushAmt),


### PR DESCRIPTION
This switches the checkCanReceiveInvoice/checkCanSendPayment preflight
checks to only verify total bandwidth instead of per-channel bandwidth.

Now that dcrlnd supports both sending and receiving multi-path payments,
it doesn't make sense to look for a specific channel with the required
bandwidth.

