### PR TITLE
lnd: Sleep before stopping wallet unlocker server

### DIFF
--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -8303,10 +8303,12 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 	for _, node := range channelGraph.Nodes {
 		if node.PubKey == net.Bob.PubKeyStr {
+			t.Logf("Full channel graph: %s", spew.Sdump(channelGraph))
 			t.Fatalf("did not expect to find bob in the channel " +
 				"graph, but did")
 		}
 		if node.PubKey == carol.PubKeyStr {
+			t.Logf("Full channel graph: %s", spew.Sdump(channelGraph))
 			t.Fatalf("did not expect to find carol in the channel " +
 				"graph, but did")
 		}


### PR DESCRIPTION
This adds a time.Sleep() call before stopping the gRPC server used for
the wallet unlocker service and consequently before closing the
listeners for the given server.

Some gRPC client libraries, such as grpc-js used in nodejs/Electron apps
(i.e. Decrediton) have trouble processing the response to a call if the
socket is closed immediately after the response is returned.

The gRPC library currently used in dcrlnd does not offer any method of
identifying whether there are outstanding calls or clients, therefore we
resort to a simple sleep that, while not fundamentally fixing the
underlying issue, alleviates it for the most common use case.
