### PR TITLE
Add SECURITY.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,22 +114,7 @@ loss of funds.
 
 ## Security
 
-`dcrlnd` is now part of Decred's [Bug Bounty Program](https://bounty.decred.org)
-on an experimental basis while we haven't yet deployed into mainnet.
-
-Additionally, given the current nature of this work as a fork from the original
-`lnd` code, bugs that have been submitted to the upstream `lnd` project are **not**
-eligible for the bug bounty program _unless_ the following points apply:
-
-  - The bug affects a mainnet worthy release of `dcrlnd`;
-  - The fix for the bug was _not_ merged from the upstream repo while a
-  substantial amount of upstream commits that are newer than the relevant one
-  were merged;
-  - The bug is not critical to `lnd` but it is to `dcrlnd`.
-
-To submit `dcrlnd` bugs eligible for inclusion in the program, please visit the
-[Bug Bounty Website](https://bounty.decred.org) and follow the instructions
-there.
+Please see the [security policy](../security/policy). 
 
 ## Further reading
 * [Step-by-step send payment guide with docker](https://github.com/decred/dcrlnd/tree/master/docker)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ loss of funds.
 
 ## Security
 
-Please see the [security policy](../security/policy). 
+Please see the [security policy](https://github.com/decred/dcrlnd/security/policy). 
 
 ## Further reading
 * [Step-by-step send payment guide with docker](https://github.com/decred/dcrlnd/tree/master/docker)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The Decred project runs a bug bounty program which is approved by the stakeholders and is funded by the Decred treasury.
+
+Please refer to the bounty website to understand the [scope](https://bounty.decred.org/#Scope) and how to [submit](https://bounty.decred.org/#Submit%20Vulnerability) a vulnerability.
+
+https://bounty.decred.org/
+
+## Supported Versions
+
+All bugs must be reproducible in the latest production release or the master branch of the code.
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,5 +10,15 @@ https://bounty.decred.org/
 
 ## Supported Versions
 
-All bugs must be reproducible in the latest production release or the master branch of the code.
+`dcrlnd` is part of Decred's [Bug Bounty Program](https://bounty.decred.org)
+on an experimental basis while we haven't yet deployed into mainnet.
 
+Additionally, given the current nature of this work as a fork from the original
+`lnd` code, bugs that have been submitted to the upstream `lnd` project are **not**
+eligible for the bug bounty program _unless_ the following points apply:
+
+  - The bug affects a mainnet worthy release of `dcrlnd`;
+  - The fix for the bug was _not_ merged from the upstream repo while a
+  substantial amount of upstream commits that are newer than the relevant one
+  were merged;
+  - The bug is not critical to `lnd` but it is to `dcrlnd`.


### PR DESCRIPTION
Adds a SECURITY.md file which is shown in the [security](../security/policy) tab on github. 