### PR TITLE
docs: Improve quickstart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,16 @@ https://decred.org/community
 
 ## Installation
 
-  Knowledgeable users may use the [quickstart guide](/docs/QUICKSTART.md).
+Knowledgeable users may use the [quickstart guide](/docs/QUICKSTART.md).
 
-  For more detailed instructions, please see [the installation
-  instructions](docs/INSTALL.md).
+For more detailed instructions, please see [the installation
+instructions](docs/INSTALL.md).
 
-  And a sample config file with annotated options is [also available here](sample-dcrlnd.conf).
+The [operation modes](docs/operation_modes.md) document lists how `dcrlnd` may
+connect to the Decred network to run its operations.
+
+And a sample config file with annotated options is [also available
+here](sample-dcrlnd.conf).
 
 ## Quick Simnet Network
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,9 +2,10 @@
 
 Super quick start, for knowledgeable individuals.
 
-- Use Go >= 1.13
-- Git clone as usual
-- Install as usual:
+- Use Go >= 1.16
+- Clone repo
+  - `git clone https://github.com/decred/dcrlnd`
+- Install:
   - `go install ./cmd/dcrlnd`
   - `go install ./cmd/dcrlncli`
 - These should now work:
@@ -20,21 +21,13 @@ Create the config file ( `~/.dcrlnd/dcrlnd.conf` on linux,
 ```
 [Application Options]
 
-debuglevel = debug
-# alias = "add a descriptive name and uncomment"
-
-[Decred]
-node = "dcrd"
+node = "dcrw"
 testnet = 1
 
-[dcrd]
-dcrd.rpchost = localhost:19109
-dcrd.rpcuser = USER
-dcrd.rpcpass = PASSWORD
-dcrd.rpccert = /home/user/.dcrd/rpc.cert
-```
+[dcrwallet]
 
-Modify as needed.
+dcrwallet.spv = 1
+```
 
 # Running
 
@@ -44,7 +37,13 @@ Create the wallet: `$ dcrlncli create`. Use a minimum of 8 char password. Save t
 
 # Interacting
 
-To make it easier: `$ alias ln=dcrlncli --testnet` (the important bit is to always specify `--testnet` when invoking `dcrlncli`).
+To make it easier to interact to the node (The important bit is to always
+specify `--testnet` when invoking `dcrlncli`):
+
+```
+$ alias ln=dcrlncli --testnet`
+```
+
 
 Get a new wallet address: `$ ln newaddress`.
 
@@ -52,9 +51,10 @@ Send funds to it (hint: [faucet.decred.org](https://faucet.decred.org)).
 
 Get the balance: `$ ln walletbalance`
 
-Connect to an online node: `$ ln connect 0374ee2dec7de3732c42b4f8229c001c4297b4858fac27069b4bdba854348916a8@207.246.122.217`
+Connect to an online node: `$ ln connect
+038fde001dbe4d6286ab168cfd1e9711ad0cbb8fc4e3c2312f2b42063b72af8e71@207.246.122.217:9735`
 
-Open a channel: `$ ln openchannel --node_key=0374ee2dec7de3732c42b4f8229c001c4297b4858fac27069b4bdba854348916a8 --local_amt=100000000 --push_amt 50000000`
+Open a channel: `$ ln openchannel --node_key=038fde001dbe4d6286ab168cfd1e9711ad0cbb8fc4e3c2312f2b42063b72af8e71 --local_amt=100000000 --push_amt 50000000`
 
 Check on channel status:
 
@@ -63,7 +63,7 @@ $ ln pendingchannels
 $ ln listchannels
 ```
 
-Create a payment request (invoice): `$ ln addinvoice --amt=6969 --memo="Time_to_ pay_the_piper!"`
+Create a payment request (invoice): `$ ln addinvoice --amt=6969 --memo="Time_to_pay_the_piper!"`
 
 Pay a payment request:
 

--- a/docs/operation_modes.md
+++ b/docs/operation_modes.md
@@ -1,0 +1,127 @@
+# dcrlnd Operation Modes
+
+`dcrlnd` supports multiple operation modes. The choices are:
+
+- Chain Operations
+  - through dcrd
+  - through the underlying wallet
+- On-Chain Wallet Operations
+  - using embedded wallet
+  - using remote wallet
+
+
+The following table lists the trade-offs for each combination:
+
+| Combination | Characteristcs |
+| --- | --- |
+| dcrd + embedded wallet | - Safest for on-chain ops <br> - Fastest on-chain sync <br> - 2 daemons to maintain  <br> - Best for standalone hubs |
+| dcrd + remote wallet | - Safest for on-chain ops <br> - No additional seeds to manage <br> - 3 daemons to maintain <br> - Hardest to setup <br> - Useful when user already maintains hot wallet |
+| spv + embedded wallet | - Simplest to setup <br> - Slower on-chain sync <br> - 1 daemon to maintain |
+| spv + remote wallet | - No additional seeds to manange <br> - 2 daemons to maintain <br> - Useful for integrating into existing setups (e.g. Decrediton) |
+
+The following sections detail what the choices imply. After that, sample config
+files are provided for the different combinations.
+
+## Chain Operations: dcrd vs wallet
+
+`dcrlnd` requires access to the Decred P2P network in order to perform its
+on-chain duties (open and close channels, detect force closures, send and
+receive on-chain funds, etc).
+
+Using an underlying `dcrd` instance is the safest option here, since it ensures
+`dcrlnd` has access to a completely valid chain and mempool.
+
+It's also the fastest option, given that the the wallet syncs faster when
+running in RPC mode (either the embedded one or a remote wallet).
+
+The drawback of using a `dcrd` instance is having to also maintain it as an
+online service and to ensure `dcrlnd` always has access to it.
+
+When operating an always-on `dcrlnd` hub node, it's the recommended chain sync
+option.
+
+The advantage of using the wallet itself (possibly in SPV mode) for chain 
+operations is that it simplifies the setup a bit and removes the need to
+maintain another service online.
+
+## Wallet Operations: embedded vs remote
+
+`dcrlnd` also requies access to a `dcrwallet` instance in order to perform its
+on-chain wallet operations (signing transactions, funding and withdrawing funds
+from channels, etc).
+
+When running in embedded wallet mode, `dcrlnd` creates its own internal instance
+of `dcrwallet` and manages its operation directly. This simplifies the
+deployment by avoiding the need to run and maintain a separate `dcrwallet`
+service running, but has the drawback that the user needs to maintain an
+additional seed: the seed to the on-chain side of `dcrlnd`'s operations.
+
+Using a remote wallet is useful when the user already maintains an online, hot
+wallet due to other reasons (for example due to continuously running
+stakeshuffle sessions, solo voting or something else). This is also useful for
+integrating to other applications (such as Decrediton) where the user already
+has a wallet.
+
+Note that it's **strongly** recommended to use a **separate**, **dedicated**
+account to LN operations when connecting to an already running wallet to avoid
+`dcrlnd` operations interfering with standard wallet usage (and vice-versa).
+
+
+## Sample Configs
+
+The following are the absolute minimum configuration necessary to run each
+combination. Additional config (such as `testnet = 1`) might be necessary
+according to the specific use case.
+
+### dcrd + Embedded Wallet
+
+```ini
+[Application Options]
+
+node = dcrd
+
+[Dcrd]
+
+dcrd.rpchost = localhost
+dcrd.rpcuser = USER
+dcrd.rpcpass = PASSWORD
+dcrd.rpccert = ~/.dcrd/rpc.cert
+```
+
+### spv + Embedded Wallet
+
+```ini
+[Application Options]
+
+node = "dcrw"
+
+[dcrwallet]
+
+dcrwallet.spv = 1
+
+```
+
+
+### Remote Wallet
+
+This is applicable to a wallet that runs both in RPC and SPV mode, since it's
+the wallet that is going to determine how the sync happens. 
+
+Chain operations always happen through the wallet. See the [Remote Dcrwallet
+Mode](./remote_dcrwallet.md) doc for additional info on setting up this mode of
+operation.
+
+```ini
+[Application Options]
+
+node = dcrw
+
+[dcrwallet]
+
+dcrwallet.grpchost = 127.0.0.1:19221
+dcrwallet.certpath = ~/.dcrwallet/rpc.cert 
+dcrwallet.accountnumber = 1
+dcrwallet.clientkeypath = /path/to/client-ca.key
+dcrwallet.clientcertpath = /path/to/client-ca.cert
+
+```

--- a/sample-dcrlnd.conf
+++ b/sample-dcrlnd.conf
@@ -22,7 +22,6 @@
 ; it hasn't yet received a response.
 ; acceptortimeout=15s
 
-
 ; Path to TLS certificate for lnd's RPC and REST services.
 ; tlscertpath=~/.lnd/tls.cert
 
@@ -158,9 +157,6 @@
 ; intelligence services.
 ; color=#3399FF
 
-
-[Decred]
-
 ; Use Decred's test network.
 ; testnet=1
 ;
@@ -170,7 +166,10 @@
 ; Use Decred's regression test network
 ; regtest=false
 
-; Use the dcrd back-end
+; Which node to use for on-chain operations. Either 'dcrd' or 'dcrw'.
+; * 'dcrd' intructs dcrlnd to connect to a dcrd instance and perform on-chain
+;   operations through it.
+; * 'dcrw' instructs dcrlnd to use the wallet for on-chain operations.
 ; node=dcrd
 
 ; The default number of confirmations a channel must have before it's considered
@@ -212,14 +211,26 @@
 
 ; Host of the running dcrwallet. If port is omitted,
 ; then the default port for selected chain parameters will be used.
-; grpchost=
+; dcrwallet.grpchost=
 
 ; Path to the file that contains the wallet's RPC cert file.
-; certpath=
+; dcrwallet.certpath=
 
 ; Account number from the wallet that should be used to derive keys for LN
 ; operations.
-; accountnumber=
+; dcrwallet.accountnumber=
+
+; Path to the client key file needed to authenticate on the remote wallet's gRPC
+; endpoint.
+; dcrwallet.clientkeypath = /path/to/client-ca.key
+
+; Path to the client certificate file needed to authenticate on the remote
+; wallet's gRPC endpoint.
+; dcrwallet.clientcertpath = /path/to/client-ca.cert
+
+; Whether to run in SPV mode when running with an embedded wallet. Note that
+; when this is specified the 'node' parameter MUST be set to 'dcrw'.
+; dcrwallet.spv = 1
 
 [autopilot]
 


### PR DESCRIPTION
This improves the quickstart docs and adds a new doc that summarizes the
existing operation modes for a dcrlnd instance.

It also fixes some incorrect config entries in the sample config file.

