### PR TITLE
multi: Update build tags to go1.17 format

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package dcrlnd

--- a/build/deployment_dev.go
+++ b/build/deployment_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package build

--- a/build/deployment_prod.go
+++ b/build/deployment_prod.go
@@ -1,3 +1,4 @@
+//go:build !dev
 // +build !dev
 
 package build

--- a/build/log_default.go
+++ b/build/log_default.go
@@ -1,3 +1,4 @@
+//go:build !stdlog && !nolog && !filelog
 // +build !stdlog,!nolog,!filelog
 
 package build

--- a/build/log_filelog.go
+++ b/build/log_filelog.go
@@ -1,3 +1,4 @@
+//go:build filelog
 // +build filelog
 
 package build

--- a/build/log_nolog.go
+++ b/build/log_nolog.go
@@ -1,3 +1,4 @@
+//go:build nolog
 // +build nolog
 
 package build

--- a/build/log_stdlog.go
+++ b/build/log_stdlog.go
@@ -1,3 +1,4 @@
+//go:build stdlog
 // +build stdlog
 
 package build

--- a/build/loglevel_critical.go
+++ b/build/loglevel_critical.go
@@ -1,3 +1,4 @@
+//go:build dev && critical
 // +build dev,critical
 
 package build

--- a/build/loglevel_debug.go
+++ b/build/loglevel_debug.go
@@ -1,3 +1,4 @@
+//go:build dev && debug
 // +build dev,debug
 
 package build

--- a/build/loglevel_default.go
+++ b/build/loglevel_default.go
@@ -1,3 +1,4 @@
+//go:build !info && !debug && !trace && !warn && !error && !critical && !off
 // +build !info,!debug,!trace,!warn,!error,!critical,!off
 
 package build

--- a/build/loglevel_error.go
+++ b/build/loglevel_error.go
@@ -1,3 +1,4 @@
+//go:build dev && error
 // +build dev,error
 
 package build

--- a/build/loglevel_info.go
+++ b/build/loglevel_info.go
@@ -1,3 +1,4 @@
+//go:build dev && info
 // +build dev,info
 
 package build

--- a/build/loglevel_off.go
+++ b/build/loglevel_off.go
@@ -1,3 +1,4 @@
+//go:build dev && off
 // +build dev,off
 
 package build

--- a/build/loglevel_trace.go
+++ b/build/loglevel_trace.go
@@ -1,3 +1,4 @@
+//go:build dev && trace
 // +build dev,trace
 
 package build

--- a/build/loglevel_warn.go
+++ b/build/loglevel_warn.go
@@ -1,3 +1,4 @@
+//go:build dev && warn
 // +build dev,warn
 
 package build

--- a/chainntnfs/chainscannotify/csnotify_dev.go
+++ b/chainntnfs/chainscannotify/csnotify_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package csnotify

--- a/chainntnfs/dcrdnotify/dcrd_dev.go
+++ b/chainntnfs/dcrdnotify/dcrd_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package dcrdnotify

--- a/chainntnfs/dcrdnotify/dcrd_test.go
+++ b/chainntnfs/dcrdnotify/dcrd_test.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package dcrdnotify

--- a/chainntnfs/interface_dev.go
+++ b/chainntnfs/interface_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package chainntnfs

--- a/chainntnfs/interface_test.go
+++ b/chainntnfs/interface_test.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package chainntnfs_test

--- a/chainntnfs/test_utils.go
+++ b/chainntnfs/test_utils.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package chainntnfs

--- a/channeldb/kvdb/etcd/bucket.go
+++ b/channeldb/kvdb/etcd/bucket.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/bucket_test.go
+++ b/channeldb/kvdb/etcd/bucket_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/db.go
+++ b/channeldb/kvdb/etcd/db.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/db_test.go
+++ b/channeldb/kvdb/etcd/db_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/driver.go
+++ b/channeldb/kvdb/etcd/driver.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/driver_test.go
+++ b/channeldb/kvdb/etcd/driver_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/embed.go
+++ b/channeldb/kvdb/etcd/embed.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/fixture_test.go
+++ b/channeldb/kvdb/etcd/fixture_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/readwrite_bucket.go
+++ b/channeldb/kvdb/etcd/readwrite_bucket.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/readwrite_bucket_test.go
+++ b/channeldb/kvdb/etcd/readwrite_bucket_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/readwrite_cursor.go
+++ b/channeldb/kvdb/etcd/readwrite_cursor.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/readwrite_cursor_test.go
+++ b/channeldb/kvdb/etcd/readwrite_cursor_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/readwrite_tx.go
+++ b/channeldb/kvdb/etcd/readwrite_tx.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/readwrite_tx_test.go
+++ b/channeldb/kvdb/etcd/readwrite_tx_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/stm.go
+++ b/channeldb/kvdb/etcd/stm.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/stm_test.go
+++ b/channeldb/kvdb/etcd/stm_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/etcd/walletdb_interface_test.go
+++ b/channeldb/kvdb/etcd/walletdb_interface_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/channeldb/kvdb/kvdb_etcd.go
+++ b/channeldb/kvdb/kvdb_etcd.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package kvdb

--- a/channeldb/kvdb/kvdb_no_etcd.go
+++ b/channeldb/kvdb/kvdb_no_etcd.go
@@ -1,3 +1,4 @@
+//go:build !kvdb_etcd
 // +build !kvdb_etcd
 
 package kvdb

--- a/cmd/dcrlncli/autopilotrpc_active.go
+++ b/cmd/dcrlncli/autopilotrpc_active.go
@@ -1,3 +1,4 @@
+//go:build !no_autopilotrpc
 // +build !no_autopilotrpc
 
 package main

--- a/cmd/dcrlncli/autopilotrpc_disabled.go
+++ b/cmd/dcrlncli/autopilotrpc_disabled.go
@@ -1,3 +1,4 @@
+//go:build no_autopilotrpc
 // +build no_autopilotrpc
 
 package main

--- a/cmd/dcrlncli/invoicesrpc_active.go
+++ b/cmd/dcrlncli/invoicesrpc_active.go
@@ -1,3 +1,4 @@
+//go:build !no_invoicesrpc
 // +build !no_invoicesrpc
 
 package main

--- a/cmd/dcrlncli/invoicesrpc_disabled.go
+++ b/cmd/dcrlncli/invoicesrpc_disabled.go
@@ -1,3 +1,4 @@
+//go:build no_invoicesrpc
 // +build no_invoicesrpc
 
 package main

--- a/cmd/dcrlncli/password.go
+++ b/cmd/dcrlncli/password.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main

--- a/cmd/dcrlncli/password_windows.go
+++ b/cmd/dcrlncli/password_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package main

--- a/cmd/dcrlncli/walletrpc_active.go
+++ b/cmd/dcrlncli/walletrpc_active.go
@@ -1,3 +1,4 @@
+//go:build !no_walletrpc
 // +build !no_walletrpc
 
 package main

--- a/cmd/dcrlncli/walletrpc_disabled.go
+++ b/cmd/dcrlncli/walletrpc_disabled.go
@@ -1,3 +1,4 @@
+//go:build no_walletrpc
 // +build no_walletrpc
 
 package main

--- a/cmd/dcrlncli/watchtower_active.go
+++ b/cmd/dcrlncli/watchtower_active.go
@@ -1,3 +1,4 @@
+//go:build !no_watchtowerrpc
 // +build !no_watchtowerrpc
 
 package main

--- a/cmd/dcrlncli/watchtower_disabled.go
+++ b/cmd/dcrlncli/watchtower_disabled.go
@@ -1,3 +1,4 @@
+//go:build no_watchtowerrpc
 // +build no_watchtowerrpc
 
 package main

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package dcrlnd

--- a/fuzz/brontide/fuzz_utils.go
+++ b/fuzz/brontide/fuzz_utils.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_actone.go
+++ b/fuzz/brontide/random_actone.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_actthree.go
+++ b/fuzz/brontide/random_actthree.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_acttwo.go
+++ b/fuzz/brontide/random_acttwo.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_init_decrypt.go
+++ b/fuzz/brontide/random_init_decrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_init_enc_dec.go
+++ b/fuzz/brontide/random_init_enc_dec.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_init_encrypt.go
+++ b/fuzz/brontide/random_init_encrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_resp_decrypt.go
+++ b/fuzz/brontide/random_resp_decrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_resp_enc_dec.go
+++ b/fuzz/brontide/random_resp_enc_dec.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_resp_encrypt.go
+++ b/fuzz/brontide/random_resp_encrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_actone.go
+++ b/fuzz/brontide/static_actone.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_actthree.go
+++ b/fuzz/brontide/static_actthree.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_acttwo.go
+++ b/fuzz/brontide/static_acttwo.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_init_decrypt.go
+++ b/fuzz/brontide/static_init_decrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_init_enc_dec.go
+++ b/fuzz/brontide/static_init_enc_dec.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_init_encrypt.go
+++ b/fuzz/brontide/static_init_encrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_resp_decrypt.go
+++ b/fuzz/brontide/static_resp_decrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_resp_enc_dec.go
+++ b/fuzz/brontide/static_resp_enc_dec.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_resp_encrypt.go
+++ b/fuzz/brontide/static_resp_encrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/lnwire/accept_channel.go
+++ b/fuzz/lnwire/accept_channel.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/announce_signatures.go
+++ b/fuzz/lnwire/announce_signatures.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/channel_announcement.go
+++ b/fuzz/lnwire/channel_announcement.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/channel_reestablish.go
+++ b/fuzz/lnwire/channel_reestablish.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/channel_update.go
+++ b/fuzz/lnwire/channel_update.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/closing_signed.go
+++ b/fuzz/lnwire/closing_signed.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/commit_sig.go
+++ b/fuzz/lnwire/commit_sig.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/error.go
+++ b/fuzz/lnwire/error.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/funding_created.go
+++ b/fuzz/lnwire/funding_created.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/funding_locked.go
+++ b/fuzz/lnwire/funding_locked.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/funding_signed.go
+++ b/fuzz/lnwire/funding_signed.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/fuzz_utils.go
+++ b/fuzz/lnwire/fuzz_utils.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/gossip_timestamp_range.go
+++ b/fuzz/lnwire/gossip_timestamp_range.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/init.go
+++ b/fuzz/lnwire/init.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/node_announcement.go
+++ b/fuzz/lnwire/node_announcement.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/open_channel.go
+++ b/fuzz/lnwire/open_channel.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/ping.go
+++ b/fuzz/lnwire/ping.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/pong.go
+++ b/fuzz/lnwire/pong.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/query_channel_range.go
+++ b/fuzz/lnwire/query_channel_range.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/query_short_chan_ids.go
+++ b/fuzz/lnwire/query_short_chan_ids.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/query_short_chan_ids_zlib.go
+++ b/fuzz/lnwire/query_short_chan_ids_zlib.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/reply_channel_range.go
+++ b/fuzz/lnwire/reply_channel_range.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/reply_channel_range_zlib.go
+++ b/fuzz/lnwire/reply_channel_range_zlib.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/reply_short_chan_ids_end.go
+++ b/fuzz/lnwire/reply_short_chan_ids_end.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/revoke_and_ack.go
+++ b/fuzz/lnwire/revoke_and_ack.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/shutdown.go
+++ b/fuzz/lnwire/shutdown.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/update_add_htlc.go
+++ b/fuzz/lnwire/update_add_htlc.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/update_fail_htlc.go
+++ b/fuzz/lnwire/update_fail_htlc.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/update_fail_malformed_htlc.go
+++ b/fuzz/lnwire/update_fail_malformed_htlc.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/update_fee.go
+++ b/fuzz/lnwire/update_fee.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/update_fulfill_htlc.go
+++ b/fuzz/lnwire/update_fulfill_htlc.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/wtwire/create_session.go
+++ b/fuzz/wtwire/create_session.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/create_session_reply.go
+++ b/fuzz/wtwire/create_session_reply.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/delete_session.go
+++ b/fuzz/wtwire/delete_session.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/delete_session_reply.go
+++ b/fuzz/wtwire/delete_session_reply.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/error.go
+++ b/fuzz/wtwire/error.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/fuzz_utils.go
+++ b/fuzz/wtwire/fuzz_utils.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/init.go
+++ b/fuzz/wtwire/init.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/state_update.go
+++ b/fuzz/wtwire/state_update.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/state_update_reply.go
+++ b/fuzz/wtwire/state_update_reply.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/healthcheck/diskcheck.go
+++ b/healthcheck/diskcheck.go
@@ -1,3 +1,4 @@
+//go:build !windows && !solaris && !netbsd && !openbsd
 // +build !windows,!solaris,!netbsd,!openbsd
 
 package healthcheck

--- a/htlcswitch/hodl/config_dev.go
+++ b/htlcswitch/hodl/config_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package hodl

--- a/htlcswitch/hodl/config_prod.go
+++ b/htlcswitch/hodl/config_prod.go
@@ -1,3 +1,4 @@
+//go:build !dev
 // +build !dev
 
 package hodl

--- a/htlcswitch/hodl/mask_dev.go
+++ b/htlcswitch/hodl/mask_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package hodl

--- a/htlcswitch/hodl/mask_prod.go
+++ b/htlcswitch/hodl/mask_prod.go
@@ -1,3 +1,4 @@
+//go:build !dev
 // +build !dev
 
 package hodl

--- a/lncfg/address_test.go
+++ b/lncfg/address_test.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package lncfg

--- a/lncfg/monitoring_off.go
+++ b/lncfg/monitoring_off.go
@@ -1,3 +1,4 @@
+//go:build !monitoring
 // +build !monitoring
 
 package lncfg

--- a/lncfg/monitoring_on.go
+++ b/lncfg/monitoring_on.go
@@ -1,3 +1,4 @@
+//go:build monitoring
 // +build monitoring
 
 package lncfg

--- a/lncfg/protocol_experimental_off.go
+++ b/lncfg/protocol_experimental_off.go
@@ -1,3 +1,4 @@
+//go:build !dev
 // +build !dev
 
 package lncfg

--- a/lncfg/protocol_experimental_on.go
+++ b/lncfg/protocol_experimental_on.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package lncfg

--- a/lncfg/protocol_legacy_off.go
+++ b/lncfg/protocol_legacy_off.go
@@ -1,3 +1,4 @@
+//go:build !dev
 // +build !dev
 
 package lncfg

--- a/lncfg/protocol_legacy_on.go
+++ b/lncfg/protocol_legacy_on.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package lncfg

--- a/lnrpc/autopilotrpc/autopilot_server.go
+++ b/lnrpc/autopilotrpc/autopilot_server.go
@@ -1,3 +1,4 @@
+//go:build !no_autopilotrpc
 // +build !no_autopilotrpc
 
 package autopilotrpc

--- a/lnrpc/autopilotrpc/config_active.go
+++ b/lnrpc/autopilotrpc/config_active.go
@@ -1,3 +1,4 @@
+//go:build !no_autopilotrpc
 // +build !no_autopilotrpc
 
 package autopilotrpc

--- a/lnrpc/autopilotrpc/config_disabled.go
+++ b/lnrpc/autopilotrpc/config_disabled.go
@@ -1,3 +1,4 @@
+//go:build no_autopilotrpc
 // +build no_autopilotrpc
 
 package autopilotrpc

--- a/lnrpc/autopilotrpc/driver.go
+++ b/lnrpc/autopilotrpc/driver.go
@@ -1,3 +1,4 @@
+//go:build !no_autopilotrpc
 // +build !no_autopilotrpc
 
 package autopilotrpc

--- a/lnrpc/chainrpc/chainnotifier_server.go
+++ b/lnrpc/chainrpc/chainnotifier_server.go
@@ -1,3 +1,4 @@
+//go:build !no_chainrpc
 // +build !no_chainrpc
 
 package chainrpc

--- a/lnrpc/chainrpc/config_active.go
+++ b/lnrpc/chainrpc/config_active.go
@@ -1,3 +1,4 @@
+//go:build !no_chainrpc
 // +build !no_chainrpc
 
 package chainrpc

--- a/lnrpc/chainrpc/config_disabled.go
+++ b/lnrpc/chainrpc/config_disabled.go
@@ -1,3 +1,4 @@
+//go:build no_chainrpc
 // +build no_chainrpc
 
 package chainrpc

--- a/lnrpc/chainrpc/driver.go
+++ b/lnrpc/chainrpc/driver.go
@@ -1,3 +1,4 @@
+//go:build !no_chainrpc
 // +build !no_chainrpc
 
 package chainrpc

--- a/lnrpc/invoicesrpc/config_active.go
+++ b/lnrpc/invoicesrpc/config_active.go
@@ -1,3 +1,4 @@
+//go:build !no_invoicesrpc
 // +build !no_invoicesrpc
 
 package invoicesrpc

--- a/lnrpc/invoicesrpc/config_disabled.go
+++ b/lnrpc/invoicesrpc/config_disabled.go
@@ -1,3 +1,4 @@
+//go:build no_invoicesrpc
 // +build no_invoicesrpc
 
 package invoicesrpc

--- a/lnrpc/invoicesrpc/driver.go
+++ b/lnrpc/invoicesrpc/driver.go
@@ -1,3 +1,4 @@
+//go:build !no_invoicesrpc
 // +build !no_invoicesrpc
 
 package invoicesrpc

--- a/lnrpc/invoicesrpc/invoices_server.go
+++ b/lnrpc/invoicesrpc/invoices_server.go
@@ -1,3 +1,4 @@
+//go:build !no_invoicesrpc
 // +build !no_invoicesrpc
 
 package invoicesrpc

--- a/lnrpc/signrpc/config_active.go
+++ b/lnrpc/signrpc/config_active.go
@@ -1,3 +1,4 @@
+//go:build !no_signrpc
 // +build !no_signrpc
 
 package signrpc

--- a/lnrpc/signrpc/config_disabled.go
+++ b/lnrpc/signrpc/config_disabled.go
@@ -1,3 +1,4 @@
+//go:build no_signrpc
 // +build no_signrpc
 
 package signrpc

--- a/lnrpc/signrpc/driver.go
+++ b/lnrpc/signrpc/driver.go
@@ -1,3 +1,4 @@
+//go:build !no_signrpc
 // +build !no_signrpc
 
 package signrpc

--- a/lnrpc/signrpc/signer_server.go
+++ b/lnrpc/signrpc/signer_server.go
@@ -1,3 +1,4 @@
+//go:build !no_signrpc
 // +build !no_signrpc
 
 package signrpc

--- a/lnrpc/walletrpc/config_active.go
+++ b/lnrpc/walletrpc/config_active.go
@@ -1,3 +1,4 @@
+//go:build !no_walletrpc
 // +build !no_walletrpc
 
 package walletrpc

--- a/lnrpc/walletrpc/config_disabled.go
+++ b/lnrpc/walletrpc/config_disabled.go
@@ -1,3 +1,4 @@
+//go:build no_walletrpc
 // +build no_walletrpc
 
 package walletrpc

--- a/lnrpc/walletrpc/driver.go
+++ b/lnrpc/walletrpc/driver.go
@@ -1,3 +1,4 @@
+//go:build !no_walletrpc
 // +build !no_walletrpc
 
 package walletrpc

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -1,3 +1,4 @@
+//go:build !no_walletrpc
 // +build !no_walletrpc
 
 package walletrpc

--- a/lnrpc/watchtowerrpc/config_active.go
+++ b/lnrpc/watchtowerrpc/config_active.go
@@ -1,3 +1,4 @@
+//go:build !no_watchtowerrpc
 // +build !no_watchtowerrpc
 
 package watchtowerrpc

--- a/lnrpc/watchtowerrpc/config_disabled.go
+++ b/lnrpc/watchtowerrpc/config_disabled.go
@@ -1,3 +1,4 @@
+//go:build no_watchtowerrpc
 // +build no_watchtowerrpc
 
 package watchtowerrpc

--- a/lnrpc/watchtowerrpc/driver.go
+++ b/lnrpc/watchtowerrpc/driver.go
@@ -1,3 +1,4 @@
+//go:build !no_watchtowerrpc
 // +build !no_watchtowerrpc
 
 package watchtowerrpc

--- a/lnrpc/watchtowerrpc/handler.go
+++ b/lnrpc/watchtowerrpc/handler.go
@@ -1,3 +1,4 @@
+//go:build !no_watchtowerrpc
 // +build !no_watchtowerrpc
 
 package watchtowerrpc

--- a/lntest/dcrd.go
+++ b/lntest/dcrd.go
@@ -1,3 +1,4 @@
+//go:build dcrd
 // +build dcrd
 
 package lntest

--- a/lntest/embeddedwallet-dcrd.go
+++ b/lntest/embeddedwallet-dcrd.go
@@ -1,3 +1,4 @@
+//go:build !remotewallet && !embeddedwallet_dcrw
 // +build !remotewallet,!embeddedwallet_dcrw
 
 package lntest

--- a/lntest/embeddedwallet-dcrw.go
+++ b/lntest/embeddedwallet-dcrw.go
@@ -1,3 +1,4 @@
+//go:build embeddedwallet_dcrw
 // +build embeddedwallet_dcrw
 
 package lntest

--- a/lntest/itest/dcrlnd_maxio_test.go
+++ b/lntest/itest/dcrlnd_maxio_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/dcrlnd_offline_invoice_test.go
+++ b/lntest/itest/dcrlnd_offline_invoice_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_forward_interceptor_test.go
+++ b/lntest/itest/lnd_forward_interceptor_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_macaroons_test.go
+++ b/lntest/itest/lnd_macaroons_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_max_channel_size_test.go
+++ b/lntest/itest/lnd_max_channel_size_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_mpp_test.go
+++ b/lntest/itest/lnd_mpp_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_multi-hop-error-propagation_test.go
+++ b/lntest/itest/lnd_multi-hop-error-propagation_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_multi-hop-payments_test.go
+++ b/lntest/itest/lnd_multi-hop-payments_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_multi-hop_htlc_local_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_local_timeout_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_multi-hop_local_force_close_on_chain_htlc_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_local_force_close_on_chain_htlc_timeout_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_multi-hop_test.go
+++ b/lntest/itest/lnd_multi-hop_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_onchain_test.go
+++ b/lntest/itest/lnd_onchain_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_rest_api_test.go
+++ b/lntest/itest/lnd_rest_api_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_send_multi_path_payment_test.go
+++ b/lntest/itest/lnd_send_multi_path_payment_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_single_hop_invoice_test.go
+++ b/lntest/itest/lnd_single_hop_invoice_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_wumbo_channels_test.go
+++ b/lntest/itest/lnd_wumbo_channels_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/remotewallet.go
+++ b/lntest/remotewallet.go
@@ -1,3 +1,4 @@
+//go:build remotewallet
 // +build remotewallet
 
 package lntest

--- a/lntest/spv.go
+++ b/lntest/spv.go
@@ -1,3 +1,4 @@
+//go:build spv
 // +build spv
 
 package lntest

--- a/lntest/timeouts.go
+++ b/lntest/timeouts.go
@@ -1,3 +1,4 @@
+//go:build !darwin
 // +build !darwin
 
 package lntest

--- a/lntest/timeouts_darwin.go
+++ b/lntest/timeouts_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package lntest

--- a/lnwallet/dcrwallet/loader/defaults.go
+++ b/lnwallet/dcrwallet/loader/defaults.go
@@ -1,3 +1,4 @@
+//go:build !rpctest && !unittest
 // +build !rpctest,!unittest
 
 package loader

--- a/lnwallet/dcrwallet/loader/defaults_rpctest.go
+++ b/lnwallet/dcrwallet/loader/defaults_rpctest.go
@@ -1,3 +1,4 @@
+//go:build rpctest || unittest
 // +build rpctest unittest
 
 package loader

--- a/macaroons/security.go
+++ b/macaroons/security.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package macaroons

--- a/macaroons/security_rpctest.go
+++ b/macaroons/security_rpctest.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package macaroons

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -1,3 +1,4 @@
+//go:build mobile
 // +build mobile
 
 package dcrlndmobile

--- a/monitoring/monitoring_off.go
+++ b/monitoring/monitoring_off.go
@@ -1,3 +1,4 @@
+//go:build !monitoring
 // +build !monitoring
 
 package monitoring

--- a/monitoring/monitoring_on.go
+++ b/monitoring/monitoring_on.go
@@ -1,3 +1,4 @@
+//go:build monitoring
 // +build monitoring
 
 package monitoring

--- a/nursery_store_test.go
+++ b/nursery_store_test.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package dcrlnd

--- a/routing/conf.go
+++ b/routing/conf.go
@@ -1,3 +1,4 @@
+//go:build !experimental
 // +build !experimental
 
 package routing

--- a/routing/conf_experimental.go
+++ b/routing/conf_experimental.go
@@ -1,3 +1,4 @@
+//go:build experimental
 // +build experimental
 
 package routing

--- a/server_test.go
+++ b/server_test.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package dcrlnd

--- a/sweep/defaults.go
+++ b/sweep/defaults.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package sweep

--- a/sweep/defaults_rpctest.go
+++ b/sweep/defaults_rpctest.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package sweep

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package dcrlnd

--- a/watchtower/lookout/justice_descriptor_test.go
+++ b/watchtower/lookout/justice_descriptor_test.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package lookout_test

--- a/watchtower/lookout/lookout_test.go
+++ b/watchtower/lookout/lookout_test.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package lookout_test

--- a/watchtower/lookout/mock.go
+++ b/watchtower/lookout/mock.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package lookout

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package wtclient_test


### PR DESCRIPTION
This updates all build tags to use the new preferable go1.17
'//go:build' format.

The old '+build' conditional build tag will be removed in a future go
release.
