### PR TITLE
lnwallet/dcrwallet: estimatefee for built-in wallet

### DIFF
--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"decred.org/dcrwallet/v2/wallet/txauthor"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrutil/v4"
@@ -208,8 +207,8 @@ type WalletController interface {
 	// SHOULD NOT be broadcasted.
 	//
 	// NOTE: This method requires the global coin selection lock to be held.
-	CreateSimpleTx(outputs []*wire.TxOut, feeRate chainfee.AtomPerKByte,
-		dryRun bool) (*txauthor.AuthoredTx, error)
+	EstimateTxFee(outputs []*wire.TxOut,
+		feeRate chainfee.AtomPerKByte) (fee int64, err error)
 
 	// ListUnspentWitness returns all unspent outputs which are version 0
 	// witness programs. The 'minconfirms' and 'maxconfirms' parameters

--- a/lnwallet/remotedcrwallet/wallet.go
+++ b/lnwallet/remotedcrwallet/wallet.go
@@ -14,7 +14,6 @@ import (
 	pb "decred.org/dcrwallet/v2/rpc/walletrpc"
 	"google.golang.org/grpc"
 
-	"decred.org/dcrwallet/v2/wallet/txauthor"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrec"
@@ -435,11 +434,11 @@ func (b *DcrWallet) SendOutputs(outputs []*wire.TxOut,
 // the database. A tx created with this set to true SHOULD NOT be broadcasted.
 //
 // This is a part of the WalletController interface.
-func (b *DcrWallet) CreateSimpleTx(outputs []*wire.TxOut,
-	feeRate chainfee.AtomPerKByte, dryRun bool) (*txauthor.AuthoredTx, error) {
+func (b *DcrWallet) EstimateTxFee(outputs []*wire.TxOut,
+	feeRate chainfee.AtomPerKByte) (fee int64, err error) {
 
 	// TODO(decred) Review semantics for btcwallet's CreateSimpleTx.
-	return nil, fmt.Errorf("CreateSimpleTx unimplemented for dcrwallet")
+	return 0, fmt.Errorf("CreateSimpleTx unimplemented for dcrwallet")
 }
 
 // LockOutpoint marks an outpoint as locked meaning it will no longer be deemed

--- a/mock.go
+++ b/mock.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"decred.org/dcrwallet/v2/wallet/txauthor"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrec"
@@ -299,10 +298,10 @@ func (*mockWalletController) SendOutputs(outputs []*wire.TxOut,
 	return nil, nil
 }
 
-func (*mockWalletController) CreateSimpleTx(outputs []*wire.TxOut,
-	_ chainfee.AtomPerKByte, _ bool) (*txauthor.AuthoredTx, error) {
+func (*mockWalletController) EstimateTxFee(outputs []*wire.TxOut,
+	feeRate chainfee.AtomPerKByte) (fee int64, err error) {
 
-	return nil, nil
+	return 1, nil
 }
 
 // ListUnspentWitness is called by the wallet when doing coin selection. We just

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"time"
 
-	"decred.org/dcrwallet/v2/wallet/txauthor"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrec"
@@ -241,10 +240,10 @@ func (*mockWalletController) SendOutputs(outputs []*wire.TxOut,
 	return nil, nil
 }
 
-func (*mockWalletController) CreateSimpleTx(outputs []*wire.TxOut,
-	feeRate chainfee.AtomPerKByte, dryRun bool) (*txauthor.AuthoredTx, error) {
+func (*mockWalletController) EstimateTxFee(outputs []*wire.TxOut,
+	feeRate chainfee.AtomPerKByte) (fee int64, err error) {
 
-	return nil, nil
+	return 1, nil
 }
 
 func (*mockWalletController) ListUnspentWitness(minconfirms,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -18,7 +18,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"decred.org/dcrwallet/v2/wallet/txauthor"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
@@ -1156,22 +1155,15 @@ func (r *rpcServer) EstimateFee(ctx context.Context,
 
 	// We will ask the wallet to create a tx using this fee rate. We set
 	// dryRun=true to avoid inflating the change addresses in the db.
-	var tx *txauthor.AuthoredTx
+	var totalFee int64
 	wallet := r.server.cc.wallet
 	err = wallet.WithCoinSelectLock(func() error {
-		tx, err = wallet.CreateSimpleTx(outputs, feePerKB, true)
+		totalFee, err = wallet.EstimateTxFee(outputs, feePerKB)
 		return err
 	})
 	if err != nil {
 		return nil, err
 	}
-
-	// Use the created tx to calculate the total fee.
-	totalOutput := int64(0)
-	for _, out := range tx.Tx.TxOut {
-		totalOutput += out.Value
-	}
-	totalFee := int64(tx.TotalInput) - totalOutput
 
 	resp := &lnrpc.EstimateFeeResponse{
 		FeeAtoms:            totalFee,


### PR DESCRIPTION
Enables use of `estimatefee` for built-in wallets. The old `CreateSimpleTx` btc impl created a fully signed transaction. But we are only using it to get an estimated fee based on available wallet input sizes and scripts, and the maximum signed serialized size -> fees are calculated without the need to actually sign. So I've changed `CreateSimpleTx(...) *AuthoredTx` to `EstimateTxFee(..) int64` to better capture its intent and skip the unneeded signing.

Tested by hand, but I'm also trying to work it into `interface_test.go`. 
