### PR TITLE
lnwallet/chainfee: add dcrdata-based fee estimator

### DIFF
--- a/chainregistry.go
+++ b/chainregistry.go
@@ -190,6 +190,18 @@ func newChainControlFromConfig(cfg *Config, localDB, remoteDB *channeldb.DB,
 			"unknown", cfg.registeredChains.PrimaryChain())
 	}
 
+	// If this wallet is not backed by a full node, use a web-based fee
+	// estimator.
+	if cfg.Node == "dcrw" {
+		switch {
+		case cfg.TestNet3:
+			cc.feeEstimator = chainfee.NewDCRDataEstimator(true, defaultDecredStaticFeePerKB)
+		case cfg.SimNet, cfg.TestNet3, cfg.RegTest:
+		default: // mainnet
+			cc.feeEstimator = chainfee.NewDCRDataEstimator(false, defaultDecredStaticFeePerKB)
+		}
+	}
+
 	var (
 		err       error
 		rpcConfig *rpcclient.ConnConfig


### PR DESCRIPTION
```
DCRDataFeeEstimator is an Estimator based on the common public
dcrdata servers for mainnet or testnet. The Estimator is only used
for chainControl using cfg.Node = "dcrw".

dcrdata requests did not work with the exising WebAPIEstimator
because that interface was designed around a single request returning
a map of fee estimates. dcrdata returns a map, but only supports
requesting one estimate (blockNum) at a time. The WebAPIEstimator
could have been adapted for dcrdata, but since we would need to cache
at least 4 estimates instead of 1 (and supporting no other values),
generating 4 requests on a repeated timer, I thought using a lazy-load
approach with a cache and sensible fail modes was a better option.
```