### PR TITLE
dcrwallet: Fix peers.json file location

### DIFF
--- a/build/log_default.go
+++ b/build/log_default.go
@@ -3,15 +3,22 @@
 
 package build
 
-import "os"
+import (
+	"io"
+	"os"
+)
 
 // LoggingType is a log type that writes to both stdout and the log rotator, if
 // present.
 const LoggingType = LogTypeDefault
 
+// Stdout is the writer used to actually output data of the app. By default,
+// this is the stdout file.
+var Stdout io.Writer = os.Stdout
+
 // Write writes the byte slice to both stdout and the log rotator, if present.
 func (w *LogWriter) Write(b []byte) (int, error) {
-	os.Stdout.Write(b)
+	Stdout.Write(b)
 	if w.RotatorPipe != nil {
 		w.RotatorPipe.Write(b)
 	}

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -343,10 +343,9 @@ func newChainControlFromConfig(cfg *Config, localDB, remoteDB *channeldb.DB,
 				activeNetParams.Params)
 		case true:
 			spvCfg := &dcrwallet.SPVSyncerConfig{
-				Peers: cfg.Dcrwallet.SPVConnect,
-				Net:   activeNetParams.Params,
-				AppDataDir: filepath.Join(cfg.DataDir,
-					activeNetParams.Params.Name),
+				Peers:      cfg.Dcrwallet.SPVConnect,
+				Net:        activeNetParams.Params,
+				AppDataDir: filepath.Join(cfg.ChainDir),
 			}
 			syncer, err = dcrwallet.NewSPVSyncer(spvCfg)
 		}

--- a/lnwallet/dcrwallet/log.go
+++ b/lnwallet/dcrwallet/log.go
@@ -6,6 +6,7 @@ import (
 	"decred.org/dcrwallet/v2/spv"
 	base "decred.org/dcrwallet/v2/wallet"
 	"decred.org/dcrwallet/v2/wallet/udb"
+	"github.com/decred/dcrd/addrmgr/v2"
 	"github.com/decred/dcrlnd/build"
 	"github.com/decred/dcrlnd/lnwallet/dcrwallet/loader"
 	"github.com/decred/slog"
@@ -38,4 +39,5 @@ func UseLogger(logger slog.Logger) {
 	spv.UseLogger(logger)
 	p2p.UseLogger(logger)
 	udb.UseLogger(logger)
+	addrmgr.UseLogger(logger)
 }


### PR DESCRIPTION
This fixes the expected location of the peers.json file when running an
embedded dcrwallet install in SPV mode. Previously this file was not
maintained as the path was wrong.

It also adds a commit to expose the underlying log io writer to ease debugging
in third party tools.