### PR TITLE
peer: Add stall detection and disconnection

### DIFF
--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -38,7 +38,7 @@ const (
 	pingInterval = 1 * time.Minute
 
 	// idleTimeout is the duration of inactivity before we time out a peer.
-	idleTimeout = 5 * time.Minute
+	idleTimeout = pingInterval + pingInterval/2
 
 	// writeMessageTimeout is the timeout used when writing a message to the
 	// peer.


### PR DESCRIPTION
This adds stall detection with a subsequent disconnection in writer loop of the node. This is useful in detecting scenarios where the local peer stalled due to (for example) being previously suspended.