### PR TITLE
multi: bring upstream fixes for force closures after reconnection

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -2296,8 +2296,9 @@ func (c *OpenChannel) AdvanceCommitChainTail(fwdPkg *FwdPkg,
 		// in their new commitment.
 		updateBytes := chanBucket.Get(unsignedAckedUpdatesKey)
 		if updateBytes == nil {
-			// If there are no updates to sign, we don't need to
-			// filter out any updates.
+			// This shouldn't normally happen as we always store
+			// the number of updates, but could still be
+			// encountered by nodes that are upgrading.
 			newRemoteCommit = &newCommit.Commitment
 			return nil
 		}

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -35,7 +35,7 @@ var (
 	// previously open, but now closed channels.
 	closedChannelBucket = []byte("closed-chan-bucket")
 
-	// openChanBucket stores all the currently open channels. This bucket
+	// openChannelBucket stores all the currently open channels. This bucket
 	// has a second, nested bucket which is keyed by a node's ID. Within
 	// that node ID bucket, all attributes required to track, update, and
 	// close a channel are stored.
@@ -120,6 +120,11 @@ var (
 	// active "frozen" channels. This key is present only in the leaf
 	// bucket for a given channel.
 	frozenChanKey = []byte("frozen-chans")
+
+	// lastWasRevokeKey is a key that stores true when the last update we sent
+	// was a revocation and false when it was a commitment signature. This is
+	// nil in the case of new channels with no updates exchanged.
+	lastWasRevokeKey = []byte("last-was-revoke")
 )
 
 var (
@@ -194,7 +199,7 @@ const (
 	// funded symmetrically or asymmetrically.
 	DualFunderBit ChannelType = 1 << 0
 
-	// SingleFunderTweakless is similar to the basic SingleFunder channel
+	// SingleFunderTweaklessBit is similar to the basic SingleFunder channel
 	// type, but it omits the tweak for one's key in the commitment
 	// transaction of the remote party.
 	SingleFunderTweaklessBit ChannelType = 1 << 1
@@ -668,6 +673,10 @@ type OpenChannel struct {
 	// this channel. If the value is lower than 500,000, then it's
 	// interpreted as a relative height, or an absolute height otherwise.
 	ThawHeight uint32
+
+	// LastWasRevoke is a boolean that determines if the last update we sent
+	// was a revocation (true) or a commitment signature (false).
+	LastWasRevoke bool
 
 	// TODO(roasbeef): eww
 	Db *DB
@@ -1452,6 +1461,17 @@ func (c *OpenChannel) UpdateCommitment(newCommitment *ChannelCommitment,
 				"updates: %v", err)
 		}
 
+		// Since we have just sent the counterparty a revocation, store true
+		// under lastWasRevokeKey.
+		var b2 bytes.Buffer
+		if err := WriteElements(&b2, true); err != nil {
+			return err
+		}
+
+		if err := chanBucket.Put(lastWasRevokeKey, b2.Bytes()); err != nil {
+			return err
+		}
+
 		// Persist the remote unsigned local updates that are not included
 		// in our new commitment.
 		updateBytes := chanBucket.Get(remoteUnsignedLocalUpdatesKey)
@@ -1474,13 +1494,13 @@ func (c *OpenChannel) UpdateCommitment(newCommitment *ChannelCommitment,
 			}
 		}
 
-		var b2 bytes.Buffer
-		err = serializeLogUpdates(&b2, validUpdates)
+		var b3 bytes.Buffer
+		err = serializeLogUpdates(&b3, validUpdates)
 		if err != nil {
 			return fmt.Errorf("unable to serialize log updates: %v", err)
 		}
 
-		err = chanBucket.Put(remoteUnsignedLocalUpdatesKey, b2.Bytes())
+		err = chanBucket.Put(remoteUnsignedLocalUpdatesKey, b3.Bytes())
 		if err != nil {
 			return fmt.Errorf("unable to restore chanbucket: %v", err)
 		}
@@ -2017,15 +2037,25 @@ func (c *OpenChannel) AppendRemoteCommitChain(diff *CommitDiff) error {
 			return err
 		}
 
+		// We are sending a commitment signature so lastWasRevokeKey should
+		// store false.
+		var b bytes.Buffer
+		if err := WriteElements(&b, false); err != nil {
+			return err
+		}
+		if err := chanBucket.Put(lastWasRevokeKey, b.Bytes()); err != nil {
+			return err
+		}
+
 		// TODO(roasbeef): use seqno to derive key for later LCP
 
 		// With the bucket retrieved, we'll now serialize the commit
 		// diff itself, and write it to disk.
-		var b bytes.Buffer
-		if err := serializeCommitDiff(&b, diff); err != nil {
+		var b2 bytes.Buffer
+		if err := serializeCommitDiff(&b2, diff); err != nil {
 			return err
 		}
-		return chanBucket.Put(commitDiffKey, b.Bytes())
+		return chanBucket.Put(commitDiffKey, b2.Bytes())
 	})
 }
 
@@ -3293,6 +3323,21 @@ func fetchChanInfo(chanBucket kvdb.RBucket, channel *OpenChannel) error {
 	}
 	if err := readChanConfig(r, &channel.RemoteChanCfg); err != nil {
 		return err
+	}
+
+	// Retrieve the boolean stored under lastWasRevokeKey.
+	lastWasRevokeBytes := chanBucket.Get(lastWasRevokeKey)
+	if lastWasRevokeBytes == nil {
+		// If nothing has been stored under this key, we store false in the
+		// OpenChannel struct.
+		channel.LastWasRevoke = false
+	} else {
+		// Otherwise, read the value into the LastWasRevoke field.
+		revokeReader := bytes.NewReader(lastWasRevokeBytes)
+		err := ReadElements(revokeReader, &channel.LastWasRevoke)
+		if err != nil {
+			return err
+		}
 	}
 
 	channel.Packager = NewChannelPackager(channel.ShortChannelID)

--- a/docs/upstream-prs.csv
+++ b/docs/upstream-prs.csv
@@ -952,3 +952,6 @@ $20b42ce26			cli improv
 4620			bugfix chainntfs
 4421			improv tls
 4601		v0.11.1-beta	improv psbt
+4915			fix reconnect transmission order; brought earlier
+5231			fix force close on reconnect; brought earlier
+6655			fix disconnect procedure; brought earlier

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -15,8 +15,10 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
+	"github.com/stretchr/testify/require"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/wire"
@@ -159,6 +161,276 @@ func createInterceptorFunc(prefix, receiver string, messages []expectedMessage,
 		}
 		return false, nil
 	}
+}
+
+// TestChannelLinkRevThenSig tests that if a link owes both a revocation and a
+// signature to the counterparty (in this order), that they are sent as rev and
+// then sig.
+//
+// Specifically, this tests the following scenario:
+//
+// A               B
+//
+//	<----add-----
+//	-----add---->
+//	<----sig-----
+//	-----rev----x
+//	-----sig----x
+func TestChannelLinkRevThenSig(t *testing.T) {
+	t.Parallel()
+
+	const chanAmt = dcrutil.AtomsPerCoin * 5
+	const chanReserve = dcrutil.AtomsPerCoin * 1
+	aliceLink, bobChannel, batchTicker, start, cleanUp, restore, err :=
+		newSingleLinkTestHarness(chanAmt, chanReserve)
+	require.NoError(t, err)
+	defer cleanUp()
+
+	err = start()
+	require.NoError(t, err)
+	defer aliceLink.Stop()
+
+	alice := newPersistentLinkHarness(
+		t, aliceLink, batchTicker, restore,
+	)
+
+	var (
+		coreLink  = aliceLink.(*channelLink)
+		aliceMsgs = coreLink.cfg.Peer.(*mockPeer).sentMsgs
+	)
+
+	ctx := linkTestContext{
+		t:          t,
+		aliceLink:  aliceLink,
+		aliceMsgs:  aliceMsgs,
+		bobChannel: bobChannel,
+	}
+
+	bobHtlc1 := generateHtlc(t, coreLink, 0)
+
+	// <-----add-----
+	// Send an htlc from Bob to Alice.
+	ctx.sendHtlcBobToAlice(bobHtlc1)
+
+	aliceHtlc1, _ := generateHtlcAndInvoice(t, 0)
+
+	// ------add---->
+	ctx.sendHtlcAliceToBob(0, aliceHtlc1)
+	ctx.receiveHtlcAliceToBob()
+
+	// <-----sig-----
+	ctx.sendCommitSigBobToAlice(1)
+
+	// ------rev----x
+	var msg lnwire.Message
+	select {
+	case msg = <-aliceMsgs:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("did not receive message")
+	}
+
+	_, ok := msg.(*lnwire.RevokeAndAck)
+	require.True(t, ok)
+
+	// ------sig----x
+	// Trigger a commitsig from Alice->Bob.
+	select {
+	case batchTicker <- time.Now():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("could not force commit sig")
+	}
+
+	select {
+	case msg = <-aliceMsgs:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("did not receive message")
+	}
+
+	comSig, ok := msg.(*lnwire.CommitSig)
+	require.True(t, ok)
+
+	if len(comSig.HtlcSigs) != 2 {
+		t.Fatalf("expected 2 htlc sigs, got %d", len(comSig.HtlcSigs))
+	}
+
+	// Restart Alice so she sends and accepts ChannelReestablish.
+	cleanUp = alice.restart(false, true)
+	defer cleanUp()
+
+	ctx.aliceLink = alice.link
+	ctx.aliceMsgs = alice.msgs
+
+	// Restart Bob as well by calling NewLightningChannel.
+	bobSigner := bobChannel.Signer
+	bobPool := lnwallet.NewSigPool(runtime.NumCPU(), bobSigner)
+	bobChannel, err = lnwallet.NewLightningChannel(
+		bobSigner, bobChannel.State(), bobPool,
+		chaincfg.RegNetParams(),
+	)
+	require.NoError(t, err)
+	err = bobPool.Start()
+	require.NoError(t, err)
+
+	ctx.bobChannel = bobChannel
+
+	// --reestablish->
+	select {
+	case msg = <-ctx.aliceMsgs:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("did not receive message")
+	}
+
+	_, ok = msg.(*lnwire.ChannelReestablish)
+	require.True(t, ok)
+
+	// <-reestablish--
+	bobReest, err := bobChannel.State().ChanSyncMsg()
+	require.NoError(t, err)
+	ctx.aliceLink.HandleChannelUpdate(bobReest)
+
+	// ------rev---->
+	ctx.receiveRevAndAckAliceToBob()
+
+	// ------add---->
+	ctx.receiveHtlcAliceToBob()
+
+	// ------sig---->
+	ctx.receiveCommitSigAliceToBob(2)
+}
+
+// TestChannelLinkSigThenRev tests that if a link owes both a signature and a
+// revocation to the counterparty (in this order), that they are sent as sig
+// and then rev.
+//
+// Specifically, this tests the following scenario:
+//
+// A               B
+//
+//	<----add-----
+//	-----add---->
+//	-----sig----x
+//	<----sig-----
+//	-----rev----x
+func TestChannelLinkSigThenRev(t *testing.T) {
+	t.Parallel()
+
+	const chanAmt = dcrutil.AtomsPerCoin * 5
+	const chanReserve = dcrutil.AtomsPerCoin * 1
+	aliceLink, bobChannel, batchTicker, start, cleanUp, restore, err :=
+		newSingleLinkTestHarness(chanAmt, chanReserve)
+	require.NoError(t, err)
+	defer cleanUp()
+
+	err = start()
+	require.NoError(t, err)
+	defer aliceLink.Stop()
+
+	alice := newPersistentLinkHarness(
+		t, aliceLink, batchTicker, restore,
+	)
+
+	var (
+		coreLink  = aliceLink.(*channelLink)
+		aliceMsgs = coreLink.cfg.Peer.(*mockPeer).sentMsgs
+	)
+
+	ctx := linkTestContext{
+		t:          t,
+		aliceLink:  aliceLink,
+		aliceMsgs:  aliceMsgs,
+		bobChannel: bobChannel,
+	}
+
+	bobHtlc1 := generateHtlc(t, coreLink, 0)
+
+	// <-----add-----
+	// Send an htlc from Bob to Alice.
+	ctx.sendHtlcBobToAlice(bobHtlc1)
+
+	aliceHtlc1, _ := generateHtlcAndInvoice(t, 0)
+
+	// ------add---->
+	ctx.sendHtlcAliceToBob(0, aliceHtlc1)
+	ctx.receiveHtlcAliceToBob()
+
+	// ------sig----x
+	// Trigger a commitsig from Alice->Bob.
+	select {
+	case batchTicker <- time.Now():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("could not force commit sig")
+	}
+
+	var msg lnwire.Message
+	select {
+	case msg = <-aliceMsgs:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("did not receive message")
+	}
+
+	comSig, ok := msg.(*lnwire.CommitSig)
+	require.True(t, ok)
+
+	if len(comSig.HtlcSigs) != 1 {
+		t.Fatalf("expected 1 htlc sig, got %d", len(comSig.HtlcSigs))
+	}
+
+	// <-----sig-----
+	ctx.sendCommitSigBobToAlice(1)
+
+	// ------rev----x
+	select {
+	case msg = <-aliceMsgs:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("did not receive message")
+	}
+
+	_, ok = msg.(*lnwire.RevokeAndAck)
+	require.True(t, ok)
+
+	// Restart Alice so she sends and accepts ChannelReestablish.
+	cleanUp = alice.restart(false, true)
+	defer cleanUp()
+
+	ctx.aliceLink = alice.link
+	ctx.aliceMsgs = alice.msgs
+
+	// Restart Bob as well by calling NewLightningChannel.
+	bobSigner := bobChannel.Signer
+	bobPool := lnwallet.NewSigPool(runtime.NumCPU(), bobSigner)
+	bobChannel, err = lnwallet.NewLightningChannel(
+		bobSigner, bobChannel.State(), bobPool,
+		chaincfg.RegNetParams(),
+	)
+	require.NoError(t, err)
+	err = bobPool.Start()
+	require.NoError(t, err)
+
+	ctx.bobChannel = bobChannel
+
+	// --reestablish->
+	select {
+	case msg = <-ctx.aliceMsgs:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("did not receive message")
+	}
+
+	_, ok = msg.(*lnwire.ChannelReestablish)
+	require.True(t, ok)
+
+	// <-reestablish--
+	bobReest, err := bobChannel.State().ChanSyncMsg()
+	require.NoError(t, err)
+	ctx.aliceLink.HandleChannelUpdate(bobReest)
+
+	// ------add---->
+	ctx.receiveHtlcAliceToBob()
+
+	// ------sig---->
+	ctx.receiveCommitSigAliceToBob(1)
+
+	// ------rev---->
+	ctx.receiveRevAndAckAliceToBob()
 }
 
 // TestChannelLinkSingleHopPayment in this test we checks the interaction
@@ -2449,7 +2721,7 @@ func TestChannelLinkTrimCircuitsPending(t *testing.T) {
 
 	// Restart Alice's link, which simulates a disconnection with the remote
 	// peer.
-	cleanUp = alice.restart(false)
+	cleanUp = alice.restart(false, false)
 	defer cleanUp()
 
 	alice.assertNumPendingNumOpenCircuits(2, 2)
@@ -2478,7 +2750,7 @@ func TestChannelLinkTrimCircuitsPending(t *testing.T) {
 	// that entire circuit map is reloaded from disk, and we can now test
 	// against the behavioral differences of committing circuits that
 	// conflict with duplicate circuits after a restart.
-	cleanUp = alice.restart(true)
+	cleanUp = alice.restart(true, false)
 	defer cleanUp()
 
 	alice.assertNumPendingNumOpenCircuits(2, 2)
@@ -2537,7 +2809,7 @@ func TestChannelLinkTrimCircuitsPending(t *testing.T) {
 	// Restart Alice's link to simulate a disconnect. Since the switch
 	// remains up throughout, the two latter HTLCs will remain in the link's
 	// mailbox, and will reprocessed upon being reattached to the link.
-	cleanUp = alice.restart(false)
+	cleanUp = alice.restart(false, false)
 	defer cleanUp()
 
 	alice.assertNumPendingNumOpenCircuits(4, 2)
@@ -2578,7 +2850,7 @@ func TestChannelLinkTrimCircuitsPending(t *testing.T) {
 	// As a final persistence check, we will restart the link and switch,
 	// wiping the latter two HTLCs from memory, and forcing their circuits
 	// to be reloaded from disk.
-	cleanUp = alice.restart(true)
+	cleanUp = alice.restart(true, false)
 	defer cleanUp()
 
 	alice.assertNumPendingNumOpenCircuits(4, 2)
@@ -2733,7 +3005,7 @@ func TestChannelLinkTrimCircuitsNoCommit(t *testing.T) {
 	// Restart Alice's link, which simulates a disconnection with the remote
 	// peer. Alice's link and switch should trim the circuits that were
 	// opened but not committed.
-	cleanUp = alice.restart(false, hodl.Commit)
+	cleanUp = alice.restart(false, false, hodl.Commit)
 	defer cleanUp()
 
 	alice.assertNumPendingNumOpenCircuits(2, 0)
@@ -2767,7 +3039,7 @@ func TestChannelLinkTrimCircuitsNoCommit(t *testing.T) {
 	// Alice again in hodl.Commit mode. Since none of the HTLCs were
 	// actually committed, the previously opened circuits should be trimmed
 	// by both the link and switch.
-	cleanUp = alice.restart(true, hodl.Commit)
+	cleanUp = alice.restart(true, false, hodl.Commit)
 	defer cleanUp()
 
 	alice.assertNumPendingNumOpenCircuits(2, 0)
@@ -2824,7 +3096,7 @@ func TestChannelLinkTrimCircuitsNoCommit(t *testing.T) {
 	// Restart Alice's link, and place her back in hodl.Commit mode. On
 	// restart, all previously opened circuits should be trimmed by both the
 	// link and the switch.
-	cleanUp = alice.restart(false, hodl.Commit)
+	cleanUp = alice.restart(false, false, hodl.Commit)
 	defer cleanUp()
 
 	alice.assertNumPendingNumOpenCircuits(4, 0)
@@ -2863,7 +3135,7 @@ func TestChannelLinkTrimCircuitsNoCommit(t *testing.T) {
 	// Finally, do one last restart of both the link and switch. This will
 	// flush the HTLCs from the mailbox. The circuits should now be trimmed
 	// for all of the HTLCs.
-	cleanUp = alice.restart(true, hodl.Commit)
+	cleanUp = alice.restart(true, false, hodl.Commit)
 	defer cleanUp()
 
 	alice.assertNumPendingNumOpenCircuits(4, 0)
@@ -3030,14 +3302,14 @@ func TestChannelLinkTrimCircuitsRemoteCommit(t *testing.T) {
 
 	// Restart Alice's link, which simulates a disconnection with the remote
 	// peer.
-	cleanUp = alice.restart(false)
+	cleanUp = alice.restart(false, false)
 	defer cleanUp()
 
 	alice.assertNumPendingNumOpenCircuits(2, 2)
 
 	// Restart the link + switch and check that the number of open circuits
 	// doesn't change.
-	cleanUp = alice.restart(true)
+	cleanUp = alice.restart(true, false)
 	defer cleanUp()
 
 	alice.assertNumPendingNumOpenCircuits(2, 2)
@@ -4035,7 +4307,7 @@ func newPersistentLinkHarness(t *testing.T, link ChannelLink,
 //
 // Any number of hodl flags can be passed as additional arguments to this
 // method. If none are provided, the mask will be extracted as hodl.MaskNone.
-func (h *persistentLinkHarness) restart(restartSwitch bool,
+func (h *persistentLinkHarness) restart(restartSwitch, syncStates bool,
 	hodlFlags ...hodl.Flag) func() {
 
 	// First, remove the link from the switch.
@@ -4061,7 +4333,7 @@ func (h *persistentLinkHarness) restart(restartSwitch bool,
 	// the database owned by the link.
 	var cleanUp func()
 	h.link, h.batchTicker, cleanUp, err = h.restartLink(
-		h.channel, restartSwitch, hodlFlags,
+		h.channel, restartSwitch, syncStates, hodlFlags,
 	)
 	if err != nil {
 		h.t.Fatalf("unable to restart alicelink: %v", err)
@@ -4138,7 +4410,7 @@ func (h *persistentLinkHarness) trySignNextCommitment() {
 // to an htlcswitch. If none is provided by the caller, a new one will be
 // created using Alice's database.
 func (h *persistentLinkHarness) restartLink(
-	aliceChannel *lnwallet.LightningChannel, restartSwitch bool,
+	aliceChannel *lnwallet.LightningChannel, restartSwitch, syncStates bool,
 	hodlFlags []hodl.Flag) (
 	ChannelLink, chan time.Time, func(), error) {
 
@@ -4209,6 +4481,7 @@ func (h *persistentLinkHarness) restartLink(
 		NotifyActiveChannel:   func(wire.OutPoint) {},
 		NotifyInactiveChannel: func(wire.OutPoint) {},
 		HtlcNotifier:          aliceSwitch.cfg.HtlcNotifier,
+		SyncStates:            syncStates,
 	}
 
 	aliceLink := NewChannelLink(aliceCfg, aliceChannel)
@@ -5794,7 +6067,7 @@ func TestChannelLinkHoldInvoiceRestart(t *testing.T) {
 	coreLink.cfg.Switch.bestHeight++
 
 	// Restart link.
-	alice.restart(false)
+	alice.restart(false, false)
 	ctx.aliceLink = alice.link
 	ctx.aliceMsgs = alice.msgs
 

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -12497,15 +12497,25 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("htlc mismatch: %v", predErr)
 	}
 
+	peerReq := &lnrpc.PeerEventSubscription{}
+	peerClient, err := dave.SubscribePeerEvents(ctxb, peerReq)
+	require.NoError(t.t, err)
+
 	// First, disconnect Dave and Alice so that their link is broken.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	if err := net.DisconnectNodes(ctxt, dave, net.Alice); err != nil {
 		t.Fatalf("unable to disconnect alice from dave: %v", err)
 	}
 
+	// Wait to receive the PEER_OFFLINE event before reconnecting them.
+	peerEvent, err := peerClient.Recv()
+	require.NoError(t.t, err)
+	require.Equal(t.t, lnrpc.PeerEvent_PEER_OFFLINE, peerEvent.GetType())
+
 	// Then, reconnect them to ensure Dave doesn't just fail back the htlc.
+	// We use EnsureConnected here in case they have already re-connected.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if err := net.ConnectNodes(ctxt, dave, net.Alice); err != nil {
+	if err := net.EnsureConnected(ctxt, dave, net.Alice); err != nil {
 		t.Fatalf("unable to reconnect alice to dave: %v", err)
 	}
 
@@ -12526,6 +12536,16 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	if err := net.DisconnectNodes(ctxt, dave, net.Alice); err != nil {
 		t.Fatalf("unable to disconnect alice from dave: %v", err)
 	}
+
+	// Wait to receive the PEER_ONLINE and then the PEER_OFFLINE event
+	// before advancing.
+	peerEvent2, err := peerClient.Recv()
+	require.NoError(t.t, err)
+	require.Equal(t.t, lnrpc.PeerEvent_PEER_ONLINE, peerEvent2.GetType())
+
+	peerEvent3, err := peerClient.Recv()
+	require.NoError(t.t, err)
+	require.Equal(t.t, lnrpc.PeerEvent_PEER_OFFLINE, peerEvent3.GetType())
 
 	// Now restart carol without hodl mode, to settle back the outstanding
 	// payments.

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3282,7 +3282,7 @@ func (lc *LightningChannel) getUnsignedAckedUpdates() []channeldb.LogUpdate {
 	chanID := lnwire.NewChanIDFromOutPoint(&lc.channelState.FundingOutpoint)
 
 	// Fetch the last remote update that we have signed for.
-	lastRemoteCommitted := lc.remoteCommitChain.tip().theirMessageIndex
+	lastRemoteCommitted := lc.remoteCommitChain.tail().theirMessageIndex
 
 	// Fetch the last remote update that we have acked.
 	lastLocalCommitted := lc.localCommitChain.tail().theirMessageIndex

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3913,16 +3913,38 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 			return nil, nil, nil, err
 		}
 
+		var commitUpdates []lnwire.Message
+
 		// Next, we'll need to send over any updates we sent as part of
 		// this new proposed commitment state.
 		for _, logUpdate := range commitDiff.LogUpdates {
-			updates = append(updates, logUpdate.UpdateMsg)
+			commitUpdates = append(commitUpdates, logUpdate.UpdateMsg)
 		}
 
 		// With the batch of updates accumulated, we'll now re-send the
 		// original CommitSig message required to re-sync their remote
 		// commitment chain with our local version of their chain.
-		updates = append(updates, commitDiff.CommitSig)
+		commitUpdates = append(commitUpdates, commitDiff.CommitSig)
+
+		// NOTE: If a revocation is not owed, then updates is empty.
+		if lc.channelState.LastWasRevoke {
+			// If lastWasRevoke is set to true, a revocation was last and we
+			// need to reorder the updates so that the revocation stored in
+			// updates comes after the LogUpdates+CommitSig.
+			//
+			// ---logupdates--->
+			// ---commitsig---->
+			// ---revocation--->
+			updates = append(commitUpdates, updates...)
+		} else {
+			// Otherwise, the revocation should come before LogUpdates
+			// + CommitSig.
+			//
+			// ---revocation--->
+			// ---logupdates--->
+			// ---commitsig---->
+			updates = append(updates, commitUpdates...)
+		}
 
 		openedCircuits = commitDiff.OpenedCircuitKeys
 		closedCircuits = commitDiff.ClosedCircuitKeys

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -2134,6 +2134,8 @@ func (lc *LightningChannel) restorePendingLocalUpdates(
 	// If we did have a dangling commit, then we'll examine which updates
 	// we included in that state and re-insert them into our update log.
 	for _, logUpdate := range pendingRemoteCommitDiff.LogUpdates {
+		logUpdate := logUpdate
+
 		payDesc, err := lc.logUpdateToPayDesc(
 			&logUpdate, lc.remoteUpdateLog, pendingHeight,
 			chainfee.AtomPerKByte(pendingCommit.FeePerKB),

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -9459,3 +9459,125 @@ func TestChannelLocalUnsignedUpdatesFailure(t *testing.T) {
 	err = newAliceChannel.ReceiveNewCommitment(bobSig, bobHtlcSigs)
 	require.NoError(t, err)
 }
+
+// TestChannelSignedAckRegression tests a previously-regressing state
+// transition no longer causes channel desynchronization.
+//
+// The full state transition of this test is:
+//
+// Alice                   Bob
+//
+//	<----add-------
+//	<----sig-------
+//	-----rev------>
+//	-----sig------>
+//	<----rev-------
+//	----settle---->
+//	-----sig------>
+//	<----rev-------
+//	<----sig-------
+//	-----add------>
+//	-----sig------>
+//	<----rev-------
+//	                *restarts*
+//	-----rev------>
+//	<----sig-------
+func TestChannelSignedAckRegression(t *testing.T) {
+	t.Parallel()
+
+	// Create test channels to test out this state transition.
+	aliceChannel, bobChannel, cleanUp, err := CreateTestChannels(
+		channeldb.SingleFunderTweaklessBit,
+	)
+	require.NoError(t, err)
+	defer cleanUp()
+
+	// Create an HTLC that Bob will send to Alice.
+	htlc, preimage := createHTLC(0, lnwire.MilliAtom(5000000))
+
+	// <----add------
+	_, err = bobChannel.AddHTLC(htlc, nil)
+	require.NoError(t, err)
+	_, err = aliceChannel.ReceiveHTLC(htlc)
+	require.NoError(t, err)
+
+	// Force a state transition to lock in the HTLC.
+	// <----sig------
+	// -----rev----->
+	// -----sig----->
+	// <----rev------
+	err = ForceStateTransition(bobChannel, aliceChannel)
+	require.NoError(t, err)
+
+	// Alice settles the HTLC back to Bob.
+	// ----settle--->
+	err = aliceChannel.SettleHTLC(preimage, uint64(0), nil, nil, nil)
+	require.NoError(t, err)
+	err = bobChannel.ReceiveHTLCSettle(preimage, uint64(0))
+	require.NoError(t, err)
+
+	// -----sig---->
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
+	require.NoError(t, err)
+	err = bobChannel.ReceiveNewCommitment(aliceSig, aliceHtlcSigs)
+	require.NoError(t, err)
+
+	// <----rev-----
+	bobRevocation, _, err := bobChannel.RevokeCurrentCommitment()
+	require.NoError(t, err)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	require.NoError(t, err)
+
+	// <----sig-----
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
+	require.NoError(t, err)
+	err = aliceChannel.ReceiveNewCommitment(bobSig, bobHtlcSigs)
+	require.NoError(t, err)
+
+	// Create an HTLC that Alice will send to Bob.
+	htlc2, _ := createHTLC(0, lnwire.MilliAtom(5000000))
+
+	// -----add---->
+	_, err = aliceChannel.AddHTLC(htlc2, nil)
+	require.NoError(t, err)
+	_, err = bobChannel.ReceiveHTLC(htlc2)
+	require.NoError(t, err)
+
+	// -----sig---->
+	aliceSig, aliceHtlcSigs, _, err = aliceChannel.SignNextCommitment()
+	require.NoError(t, err)
+	err = bobChannel.ReceiveNewCommitment(aliceSig, aliceHtlcSigs)
+	require.NoError(t, err)
+
+	// <----rev-----
+	bobRevocation, _, err = bobChannel.RevokeCurrentCommitment()
+	require.NoError(t, err)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	require.NoError(t, err)
+
+	// Restart Bob's channel state here.
+	newBobChannel, err := NewLightningChannel(
+		bobChannel.Signer, bobChannel.channelState,
+		bobChannel.sigPool, testChainParams,
+	)
+	require.NoError(t, err)
+
+	// -----rev---->
+	aliceRevocation, _, err := aliceChannel.RevokeCurrentCommitment()
+	require.NoError(t, err)
+	fwdPkg, _, _, _, err := newBobChannel.ReceiveRevocation(aliceRevocation)
+	require.NoError(t, err)
+
+	// Assert that the fwdpkg is not empty.
+	require.Equal(t, len(fwdPkg.SettleFails), 1)
+
+	// Bob should no longer fail to sign this commitment due to faulty
+	// update logs.
+	// <----sig-----
+	bobSig, bobHtlcSigs, _, err = newBobChannel.SignNextCommitment()
+	require.NoError(t, err)
+
+	// Alice should receive the new commitment without hiccups.
+	err = aliceChannel.ReceiveNewCommitment(bobSig, bobHtlcSigs)
+	require.NoError(t, err)
+}

--- a/server.go
+++ b/server.go
@@ -3515,11 +3515,9 @@ func (s *server) DisconnectPeer(pubKey *secp256k1.PublicKey) error {
 	delete(s.persistentPeers, pubStr)
 	delete(s.persistentPeersBackoff, pubStr)
 
-	// Remove the current peer from the server's internal state and signal
-	// that the peer termination watcher does not need to execute for this
-	// peer.
-	s.removePeer(peer)
-	s.ignorePeerTermination[peer] = struct{}{}
+	// Remove the peer by calling Disconnect. Previously this was done with
+	// removePeer, which bypassed the peerTerminationWatcher.
+	peer.Disconnect(fmt.Errorf("server: DisconnectPeer called"))
 
 	return nil
 }


### PR DESCRIPTION
This brings the following upstream PRs to fix issues with force closed channels after peer reconnections:

https://github.com/lightningnetwork/lnd/pull/4915
https://github.com/lightningnetwork/lnd/pull/5231
https://github.com/lightningnetwork/lnd/pull/6655