### PR TITLE
channeldb: add inflight payments index 

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -236,6 +236,12 @@ func CreateWithBackend(backend kvdb.Backend, modifiers ...OptionModifier) (*DB, 
 		return nil, err
 	}
 
+	// Run dcrlnd-specific init code (that hasn't been ported to lnd).
+	if err := chanDB.initDcrlndFeatures(); err != nil {
+		backend.Close()
+		return nil, err
+	}
+
 	return chanDB, nil
 }
 

--- a/channeldb/dcrdb.go
+++ b/channeldb/dcrdb.go
@@ -1,0 +1,17 @@
+package channeldb
+
+import "github.com/decred/dcrlnd/channeldb/kvdb"
+
+// initDcrlndFeatures initializes features that are specific to dcrlnd.
+func (db *DB) initDcrlndFeatures() error {
+	return kvdb.Update(db, func(tx kvdb.RwTx) error {
+		// If the inflight payments index bucket doesn't exist,
+		// initialize it.
+		indexBucket := tx.ReadWriteBucket(paymentsInflightIndexBucket)
+		if indexBucket == nil {
+			return recreatePaymentsInflightIndex(tx)
+		}
+
+		return nil
+	})
+}

--- a/channeldb/payment_control.go
+++ b/channeldb/payment_control.go
@@ -673,16 +673,11 @@ func ensureInFlight(payment *MPPayment) error {
 	}
 }
 
-// InFlightPayment is a wrapper around a payment that has status InFlight.
+// InFlightPayment is a wrapper around the info for a payment that has status
+// InFlight.
 type InFlightPayment struct {
 	// Info is the PaymentCreationInfo of the in-flight payment.
 	Info *PaymentCreationInfo
-
-	// Attempts is the set of payment attempts that was made to this
-	// payment hash.
-	//
-	// NOTE: Might be empty.
-	Attempts []HTLCAttemptInfo
 }
 
 // FetchInFlightPayments returns all payments with status InFlight.
@@ -716,33 +711,6 @@ func (p *PaymentControl) FetchInFlightPayments() ([]*InFlightPayment, error) {
 			inFlight.Info, err = fetchCreationInfo(bucket)
 			if err != nil {
 				return err
-			}
-
-			htlcsBucket := bucket.NestedReadBucket(
-				paymentHtlcsBucket,
-			)
-			if htlcsBucket == nil {
-				return nil
-			}
-
-			// Fetch all HTLCs attempted for this payment.
-			htlcs, err := fetchHtlcAttempts(htlcsBucket)
-			if err != nil {
-				return err
-			}
-
-			// We only care about the static info for the HTLCs
-			// still in flight, so convert the result to a slice of
-			// HTLCAttemptInfos.
-			for _, h := range htlcs {
-				// Skip HTLCs not in flight.
-				if h.Settle != nil || h.Failure != nil {
-					continue
-				}
-
-				inFlight.Attempts = append(
-					inFlight.Attempts, h.HTLCAttemptInfo,
-				)
 			}
 
 			inFlights = append(inFlights, inFlight)

--- a/channeldb/payment_control.go
+++ b/channeldb/payment_control.go
@@ -673,16 +673,9 @@ func ensureInFlight(payment *MPPayment) error {
 	}
 }
 
-// InFlightPayment is a wrapper around the info for a payment that has status
-// InFlight.
-type InFlightPayment struct {
-	// Info is the PaymentCreationInfo of the in-flight payment.
-	Info *PaymentCreationInfo
-}
-
 // FetchInFlightPayments returns all payments with status InFlight.
-func (p *PaymentControl) FetchInFlightPayments() ([]*InFlightPayment, error) {
-	var inFlights []*InFlightPayment
+func (p *PaymentControl) FetchInFlightPayments() ([]*MPPayment, error) {
+	var inFlights []*MPPayment
 	err := kvdb.View(p.db, func(tx kvdb.RTx) error {
 		payments := tx.ReadBucket(paymentsRootBucket)
 		if payments == nil {
@@ -705,15 +698,12 @@ func (p *PaymentControl) FetchInFlightPayments() ([]*InFlightPayment, error) {
 				return nil
 			}
 
-			inFlight := &InFlightPayment{}
-
-			// Get the CreationInfo.
-			inFlight.Info, err = fetchCreationInfo(bucket)
+			p, err := fetchPayment(bucket)
 			if err != nil {
 				return err
 			}
 
-			inFlights = append(inFlights, inFlight)
+			inFlights = append(inFlights, p)
 			return nil
 		})
 	})

--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -744,6 +744,15 @@ func (db *DB) DeletePayments() error {
 			}
 		}
 
+		inflightBucket := tx.ReadWriteBucket(paymentsInflightIndexBucket)
+		if inflightBucket != nil {
+			for _, k := range deleteIndexes {
+				if err := indexBucket.Delete(k); err != nil {
+					return err
+				}
+			}
+		}
+
 		return nil
 	})
 }

--- a/channeldb/payments_inflight.go
+++ b/channeldb/payments_inflight.go
@@ -1,0 +1,177 @@
+package channeldb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcwallet/walletdb"
+)
+
+var (
+	// paymentsInflightIndexBucket is the name of the top-level bucket
+	// within the database that stores an index of payment hashes that are
+	// still inflight.
+	//
+	// This is used to speedup startup by having a faster way to determine
+	// payments that are still inflight.
+	paymentsInflightIndexBucket = []byte("payments-inflight-index-bucket")
+
+	// errPaymentsInflightIndexNotExists is used to signal that the
+	// inflight payments index is disabled.
+	errPaymentsInflightIndexNotExists = errors.New("payments inflight index does not exist")
+)
+
+// paymentInflightIndexValueVersion is set as the value used in the inflight
+// payments index.
+const paymentInflightIndexValueVersion = 0
+
+// createPaymentInflightIndexEntry marks a payment with the given sequence
+// number as inflight.
+func createPaymentInflightIndexEntry(tx walletdb.ReadWriteTx, seqNum []byte) error {
+	indexBucket := tx.ReadWriteBucket(paymentsInflightIndexBucket)
+
+	// If the bucket doesn't exist, indexing of inflight payments is disabled.
+	if indexBucket == nil {
+		return nil
+	}
+
+	v := []byte{paymentInflightIndexValueVersion}
+	err := indexBucket.Put(seqNum, v)
+	if err != nil {
+		return fmt.Errorf("unable to mark inflight: %v", err)
+	}
+	return err
+}
+
+// deletePaymentInflightIndexEntry marks a payment with the given sequence
+// number as not inflight.
+func deletePaymentInflightIndexEntry(tx walletdb.ReadWriteTx, seqNum []byte) error {
+	indexBucket := tx.ReadWriteBucket(paymentsInflightIndexBucket)
+
+	// If the bucket doesn't exist, the entry can't be removed.
+	if indexBucket == nil {
+		return nil
+	}
+
+	return indexBucket.Delete(seqNum)
+}
+
+// updatePaymentInflightIndexEntry updates the entry of the given payment
+// in the inflight payments index based on the payment's status.
+func updatePaymentInflightIndexEntry(tx walletdb.ReadWriteTx, payment *MPPayment) error {
+	var seqBytes [8]byte
+	binary.BigEndian.PutUint64(seqBytes[:], payment.SequenceNum)
+
+	if payment.Status == StatusInFlight {
+		return createPaymentInflightIndexEntry(tx, seqBytes[:])
+	}
+
+	return deletePaymentInflightIndexEntry(tx, seqBytes[:])
+}
+
+// recreatePaymentsInflightIndex recreates the index of inflight payments in
+// the DB.
+func recreatePaymentsInflightIndex(tx walletdb.ReadWriteTx) error {
+	indexBucket := tx.ReadWriteBucket(paymentsInflightIndexBucket)
+	if indexBucket == nil {
+		var err error
+		_, err = tx.CreateTopLevelBucket(paymentsInflightIndexBucket)
+		if err != nil {
+			return err
+		}
+	}
+
+	payments := tx.ReadBucket(paymentsRootBucket)
+	if payments == nil {
+		return nil
+	}
+
+	var nbPayments, nbInflight uint64
+	err := payments.ForEach(func(k, _ []byte) error {
+		bucket := payments.NestedReadBucket(k)
+		if bucket == nil {
+			return fmt.Errorf("non bucket element")
+		}
+
+		p, err := fetchPayment(bucket)
+		if err != nil {
+			return err
+		}
+
+		nbPayments += 1
+		if p.Status == StatusInFlight {
+			nbInflight += 1
+		}
+
+		return updatePaymentInflightIndexEntry(tx, p)
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Recreated in-flight payments index: %d payments, %d in-flight",
+		nbPayments, nbInflight)
+
+	return nil
+}
+
+// fetchInflightPaymentsByIndex fetches the list of inflight payments using the
+// inflight payments index. If the index is disabled, errPaymentsInflightIndexNotExists
+// is returned.
+func fetchInflightPaymentsByIndex(tx walletdb.ReadTx) ([]*MPPayment, error) {
+	indexBucket := tx.ReadBucket(paymentsInflightIndexBucket)
+
+	// If the bucket doesn't exist, notify caller.
+	if indexBucket == nil {
+		return nil, errPaymentsInflightIndexNotExists
+	}
+
+	payments := tx.ReadBucket(paymentsRootBucket)
+	if payments == nil {
+		return nil, fmt.Errorf("payments root bucket does not exist")
+	}
+
+	seqIndexes := tx.ReadBucket(paymentsIndexBucket)
+	if seqIndexes == nil {
+		return nil, fmt.Errorf("index bucket does not exist")
+	}
+
+	var inFlights []*MPPayment
+	err := indexBucket.ForEach(func(k, v []byte) error {
+		hash := seqIndexes.Get(k)
+		if hash == nil {
+			return fmt.Errorf("seqnum %s does not exist in index db",
+				hex.EncodeToString(k))
+		}
+		r := bytes.NewReader(hash)
+		paymentHash, err := deserializePaymentIndex(r)
+		if err != nil {
+			return err
+		}
+
+		bucket := payments.NestedReadBucket(paymentHash[:])
+		p, err := fetchPayment(bucket)
+		if err != nil {
+			return err
+		}
+
+		// Double check our assumption that this payment is in fact
+		// in-flight. If it is not, we warn about an inconsistency
+		// but otherwise don't completely fail to load the inflight
+		// payments to avoid breaking the ability to open the app.
+		if p.Status != StatusInFlight {
+			log.Warnf("Broken assumption: Payment hash %s (seqnum %d) "+
+				"in inflight payments index is not actually "+
+				"inflight (status %s - %d)",
+				paymentHash, p.SequenceNum, p.Status, p.Status)
+			return nil
+		}
+
+		inFlights = append(inFlights, p)
+		return nil
+	})
+	return inFlights, err
+}

--- a/channeldb/payments_inflight_test.go
+++ b/channeldb/payments_inflight_test.go
@@ -1,0 +1,147 @@
+package channeldb
+
+import (
+	"testing"
+
+	"github.com/decred/dcrlnd/channeldb/kvdb"
+	"github.com/stretchr/testify/require"
+)
+
+// assertFetchesInflight asserts that calling FetchInFlightPayments returns
+// the required info.
+func assertFetchesInflight(t *testing.T, pControl *PaymentControl, info *PaymentCreationInfo) {
+	inFlight, err := pControl.FetchInFlightPayments()
+	require.Nil(t, err)
+	require.Len(t, inFlight, 1)
+	require.Equal(t, inFlight[0].Info.PaymentHash, info.PaymentHash)
+}
+
+// testPaymentInflightIndexCase is a test case for fetching inflight payments.
+// noIndex determines if the index is used from the start of the test case.
+// recreateIndex determines if the index is re-created halfway through the
+// test case.
+func testPaymentInflightIndexCase(t *testing.T, noIndex, recreateIndex bool) {
+	db, cleanup, err := MakeTestDB()
+	defer cleanup()
+
+	if err != nil {
+		t.Fatalf("unable to init db: %v", err)
+	}
+
+	pControl := NewPaymentControl(db)
+
+	// If this test case is to run without the payments inflight index, manually drop it.
+	if noIndex {
+		err = kvdb.Update(db, func(tx kvdb.RwTx) error {
+			return tx.DeleteTopLevelBucket(paymentsInflightIndexBucket)
+		})
+		require.Nil(t, err)
+	}
+
+	// Init and settle a sample payment.
+	settledInfo, settledAttempt, settlePreimage, err := genInfo()
+	require.Nil(t, err)
+	err = pControl.InitPayment(settledInfo.PaymentHash, settledInfo)
+	require.Nil(t, err)
+	_, err = pControl.RegisterAttempt(settledInfo.PaymentHash, settledAttempt)
+	require.Nil(t, err)
+	_, err = pControl.SettleAttempt(
+		settledInfo.PaymentHash, settledAttempt.AttemptID,
+		&HTLCSettleInfo{
+			Preimage: settlePreimage,
+		},
+	)
+	require.Nil(t, err)
+
+	// Init and fail a sample payment.
+	failedInfo, failedAttempt, _, err := genInfo()
+	require.Nil(t, err)
+	err = pControl.InitPayment(failedInfo.PaymentHash, failedInfo)
+	require.Nil(t, err)
+	_, err = pControl.RegisterAttempt(failedInfo.PaymentHash, failedAttempt)
+	require.Nil(t, err)
+	_, err = pControl.FailAttempt(failedInfo.PaymentHash, failedAttempt.AttemptID,
+		&HTLCFailInfo{Reason: HTLCFailUnreadable})
+	require.Nil(t, err)
+	_, err = pControl.Fail(failedInfo.PaymentHash, FailureReasonNoRoute)
+	require.Nil(t, err)
+
+	// Setup the test inflight payment.
+	info, attempt, preimg, err := genInfo()
+	require.Nil(t, err)
+
+	// Init the payment.
+	err = pControl.InitPayment(info.PaymentHash, info)
+	require.Nil(t, err)
+
+	// We should find one payment inflight.
+	assertFetchesInflight(t, pControl, info)
+
+	// Register an attempt. Still inflight.
+	_, err = pControl.RegisterAttempt(info.PaymentHash, attempt)
+	require.Nil(t, err)
+	assertFetchesInflight(t, pControl, info)
+
+	// Fail the attempt. Still inflight.
+	_, err = pControl.FailAttempt(info.PaymentHash, attempt.AttemptID,
+		&HTLCFailInfo{Reason: HTLCFailUnreadable})
+	require.Nil(t, err)
+	assertFetchesInflight(t, pControl, info)
+
+	// Make a second attempt.
+	attempt.AttemptID += 1
+	_, err = pControl.RegisterAttempt(info.PaymentHash, attempt)
+	require.Nil(t, err)
+	assertFetchesInflight(t, pControl, info)
+
+	// If the test case requires it, recreate the index and test there's
+	// still one inflight.
+	if recreateIndex {
+		err = kvdb.Update(db, func(tx kvdb.RwTx) error {
+			return recreatePaymentsInflightIndex(tx)
+		})
+		require.Nil(t, err)
+		assertFetchesInflight(t, pControl, info)
+	}
+
+	// Settle. No more inflight.
+	_, err = pControl.SettleAttempt(
+		info.PaymentHash, attempt.AttemptID,
+		&HTLCSettleInfo{
+			Preimage: preimg,
+		},
+	)
+	require.Nil(t, err)
+	inFlight, err := pControl.FetchInFlightPayments()
+	require.Nil(t, err)
+	require.Len(t, inFlight, 0)
+}
+
+func TestPaymentInflightIndex(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		noIndex  bool
+		recreate bool
+	}{{
+		name:    "no index",
+		noIndex: true,
+	}, {
+		name: "index",
+	}, {
+		name:     "index and recreate",
+		recreate: true,
+	}, {
+		name:     "no index and recreate",
+		noIndex:  true,
+		recreate: true,
+	}}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			testPaymentInflightIndexCase(t, tc.noIndex, tc.recreate)
+		})
+	}
+}

--- a/docs/upstream-prs.csv
+++ b/docs/upstream-prs.csv
@@ -956,3 +956,5 @@ $20b42ce26			cli improv
 5231			fix force close on reconnect; brought earlier
 6655			fix disconnect procedure; brought earlier
 5047			account related functions; brought earlier
+3131			clean htlcswitch result db; brought earlier
+5159			only first commit; brought earlier

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -258,3 +258,48 @@ func fetchResult(tx kvdb.RTx, pid uint64) (*networkResult, error) {
 
 	return deserializeNetworkResult(r)
 }
+
+// cleanStore removes all entries from the store, except the payment IDs given.
+// NOTE: Since every result not listed in the keep map will be deleted, care
+// should be taken to ensure no new payment attempts are being made
+// concurrently while this process is ongoing, as its result might end up being
+// deleted.
+func (store *networkResultStore) cleanStore(keep map[uint64]struct{}) error {
+	return kvdb.Update(store.db.Backend, func(tx kvdb.RwTx) error {
+		networkResults, err := tx.CreateTopLevelBucket(
+			networkResultStoreBucketKey,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Iterate through the bucket, deleting all items not in the
+		// keep map.
+		var toClean [][]byte
+		if err := networkResults.ForEach(func(k, _ []byte) error {
+			pid := binary.BigEndian.Uint64(k)
+			if _, ok := keep[pid]; ok {
+				return nil
+			}
+
+			toClean = append(toClean, k)
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		for _, k := range toClean {
+			err := networkResults.Delete(k)
+			if err != nil {
+				return err
+			}
+		}
+
+		if len(toClean) > 0 {
+			log.Infof("Removed %d stale entries from network "+
+				"result store", len(toClean))
+		}
+
+		return nil
+	})
+}

--- a/htlcswitch/payment_result_test.go
+++ b/htlcswitch/payment_result_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/decred/dcrlnd/channeldb"
 	"github.com/decred/dcrlnd/lntypes"
 	"github.com/decred/dcrlnd/lnwire"
+	"github.com/stretchr/testify/require"
 )
 
 // TestNetworkResultSerialization checks that NetworkResults are properly
@@ -179,7 +180,6 @@ func TestNetworkResultStore(t *testing.T) {
 
 	// Since we don't delete results from the store (yet), make sure we
 	// will get subscriptions for all of them.
-	// TODO(halseth): check deletion when we have reliable handoff.
 	for i := uint64(0); i < numResults; i++ {
 		sub, err := store.subscribeResult(i)
 		if err != nil {
@@ -191,5 +191,26 @@ func TestNetworkResultStore(t *testing.T) {
 		case <-time.After(1 * time.Second):
 			t.Fatalf("no result received")
 		}
+	}
+
+	// Clean the store keeping the first two results.
+	toKeep := map[uint64]struct{}{
+		0: {},
+		1: {},
+	}
+	// Finally, delete the result.
+	err = store.cleanStore(toKeep)
+	require.NoError(t, err)
+
+	// Payment IDs 0 and 1 should be found, 2 and 3 should be deleted.
+	for i := uint64(0); i < numResults; i++ {
+		_, err = store.getResult(i)
+		if i <= 1 {
+			require.NoError(t, err, "unable to get result")
+		}
+		if i >= 2 && err != ErrPaymentIDNotFound {
+			t.Fatalf("expected ErrPaymentIDNotFound, got %v", err)
+		}
+
 	}
 }

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -437,6 +437,14 @@ func (s *Switch) GetPaymentResult(paymentID uint64, paymentHash lntypes.Hash,
 	return resultChan, nil
 }
 
+// CleanStore calls the underlying result store, telling it is safe to delete
+// all entries except the ones in the keepPids map. This should be called
+// preiodically to let the switch clean up payment results that we have
+// handled.
+func (s *Switch) CleanStore(keepPids map[uint64]struct{}) error {
+	return s.networkResults.cleanStore(keepPids)
+}
+
 // SendHTLC is used by other subsystems which aren't belong to htlc switch
 // package in order to send the htlc update. The paymentID used MUST be unique
 // for this HTLC, and MUST be used only once, otherwise the switch might reject

--- a/routing/control_tower.go
+++ b/routing/control_tower.go
@@ -50,7 +50,7 @@ type ControlTower interface {
 	Fail(lntypes.Hash, channeldb.FailureReason) error
 
 	// FetchInFlightPayments returns all payments with status InFlight.
-	FetchInFlightPayments() ([]*channeldb.InFlightPayment, error)
+	FetchInFlightPayments() ([]*channeldb.MPPayment, error)
 
 	// SubscribePayment subscribes to updates for the payment with the given
 	// hash. A first update with the current state of the payment is always
@@ -213,7 +213,7 @@ func (p *controlTower) Fail(paymentHash lntypes.Hash,
 }
 
 // FetchInFlightPayments returns all payments with status InFlight.
-func (p *controlTower) FetchInFlightPayments() ([]*channeldb.InFlightPayment, error) {
+func (p *controlTower) FetchInFlightPayments() ([]*channeldb.MPPayment, error) {
 	return p.db.FetchInFlightPayments()
 }
 

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -72,6 +72,9 @@ func (m *mockPaymentAttemptDispatcher) GetPaymentResult(paymentID uint64,
 	return c, nil
 
 }
+func (m *mockPaymentAttemptDispatcher) CleanStore(map[uint64]struct{}) error {
+	return nil
+}
 
 func (m *mockPaymentAttemptDispatcher) setPaymentResult(
 	f func(firstHop lnwire.ShortChannelID) ([32]byte, error)) {
@@ -185,6 +188,10 @@ func (m *mockPayer) GetPaymentResult(paymentID uint64, _ lntypes.Hash,
 	case <-m.quit:
 		return nil, fmt.Errorf("test quitting")
 	}
+}
+
+func (m *mockPayer) CleanStore(pids map[uint64]struct{}) error {
+	return nil
 }
 
 type initArgs struct {

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -446,13 +446,8 @@ func (m *mockControlTower) FetchInFlightPayments() (
 			continue
 		}
 
-		var attempts []channeldb.HTLCAttemptInfo
-		for _, a := range p.attempts {
-			attempts = append(attempts, a.HTLCAttemptInfo)
-		}
 		ifl := channeldb.InFlightPayment{
-			Info:     &p.info,
-			Attempts: attempts,
+			Info: &p.info,
 		}
 
 		fl = append(fl, &ifl)

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -413,6 +413,12 @@ func (m *mockControlTower) FetchPayment(phash lntypes.Hash) (
 	m.Lock()
 	defer m.Unlock()
 
+	return m.fetchPayment(phash)
+}
+
+func (m *mockControlTower) fetchPayment(phash lntypes.Hash) (
+	*channeldb.MPPayment, error) {
+
 	p, ok := m.payments[phash]
 	if !ok {
 		return nil, channeldb.ErrPaymentNotInitiated
@@ -429,12 +435,11 @@ func (m *mockControlTower) FetchPayment(phash lntypes.Hash) (
 
 	// Return a copy of the current attempts.
 	mp.HTLCs = append(mp.HTLCs, p.attempts...)
-
 	return mp, nil
 }
 
 func (m *mockControlTower) FetchInFlightPayments() (
-	[]*channeldb.InFlightPayment, error) {
+	[]*channeldb.MPPayment, error) {
 
 	m.Lock()
 	defer m.Unlock()
@@ -444,8 +449,8 @@ func (m *mockControlTower) FetchInFlightPayments() (
 	}
 
 	// In flight are all payments not successful or failed.
-	var fl []*channeldb.InFlightPayment
-	for hash, p := range m.payments {
+	var fl []*channeldb.MPPayment
+	for hash := range m.payments {
 		if _, ok := m.successful[hash]; ok {
 			continue
 		}
@@ -453,11 +458,12 @@ func (m *mockControlTower) FetchInFlightPayments() (
 			continue
 		}
 
-		ifl := channeldb.InFlightPayment{
-			Info: &p.info,
+		mp, err := m.fetchPayment(hash)
+		if err != nil {
+			return nil, err
 		}
 
-		fl = append(fl, &ifl)
+		fl = append(fl, mp)
 	}
 
 	return fl, nil

--- a/routing/router.go
+++ b/routing/router.go
@@ -558,14 +558,7 @@ func (r *ChannelRouter) Start() error {
 	// until the cleaning has finished.
 	toKeep := make(map[uint64]struct{})
 	for _, p := range payments {
-		payment, err := r.cfg.Control.FetchPayment(
-			p.Info.PaymentHash,
-		)
-		if err != nil {
-			return err
-		}
-
-		for _, a := range payment.HTLCs {
+		for _, a := range p.HTLCs {
 			toKeep[a.AttemptID] = struct{}{}
 		}
 	}
@@ -578,7 +571,7 @@ func (r *ChannelRouter) Start() error {
 	for _, payment := range payments {
 		log.Infof("Resuming payment with hash %v", payment.Info.PaymentHash)
 		r.wg.Add(1)
-		go func(payment *channeldb.InFlightPayment) {
+		go func(payment *channeldb.MPPayment) {
 			defer r.wg.Done()
 
 			// We create a dummy, empty payment session such that

--- a/routing/router.go
+++ b/routing/router.go
@@ -171,6 +171,14 @@ type PaymentAttemptDispatcher interface {
 	GetPaymentResult(paymentID uint64, paymentHash lntypes.Hash,
 		deobfuscator htlcswitch.ErrorDecrypter) (
 		<-chan *htlcswitch.PaymentResult, error)
+
+	// CleanStore calls the underlying result store, telling it is safe to
+	// delete all entries except the ones in the keepPids map. This should
+	// be called preiodically to let the switch clean up payment results
+	// that we have handled.
+	// NOTE: New payment attempts MUST NOT be made after the keepPids map
+	// has been created and this method has returned.
+	CleanStore(keepPids map[uint64]struct{}) error
 }
 
 // PaymentSessionSource is an interface that defines a source for the router to
@@ -540,6 +548,30 @@ func (r *ChannelRouter) Start() error {
 	// results are properly handled.
 	payments, err := r.cfg.Control.FetchInFlightPayments()
 	if err != nil {
+		return err
+	}
+
+	// Before we restart existing payments and start accepting more
+	// payments to be made, we clean the network result store of the
+	// Switch. We do this here at startup to ensure no more payments can be
+	// made concurrently, so we know the toKeep map will be up-to-date
+	// until the cleaning has finished.
+	toKeep := make(map[uint64]struct{})
+	for _, p := range payments {
+		payment, err := r.cfg.Control.FetchPayment(
+			p.Info.PaymentHash,
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, a := range payment.HTLCs {
+			toKeep[a.AttemptID] = struct{}{}
+		}
+	}
+
+	log.Debugf("Cleaning network result store.")
+	if err := r.cfg.Payer.CleanStore(toKeep); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This index is meant to improve startup time of dcrlnd installs by removing the need to iterate through the entire set of payments in the db before continuing with channel startup.

A new index is added to the channeldb, using the payment sequence number as key to mark a given payment as still in-flight.

Once the payment is settled or fails, the entry is removed from the index.

While the code is designed to be able to work both with and without the index, no option to conditionally enable the index is exposed by the package or to the user, thus the index is always used. In the future, if this index is deemed as slowling down usage (as opposed to speeding up startup), then an option may be added to the node.

Unit tests are included to test fetching of in-flight payments both with and without the index.

Before actually adding the index, a few upstream lnd PRs are brought in to make future work easier.