### PR TITLE
multi: Improve handling of announcements of closed channels

### DIFF
--- a/channeldb/graph_extended.go
+++ b/channeldb/graph_extended.go
@@ -1,0 +1,45 @@
+package channeldb
+
+import (
+	"github.com/decred/dcrlnd/channeldb/kvdb"
+)
+
+var (
+	// knownSpentBucket is the key of a top-level bucket that tracks
+	// channels that are known to be spent by their short channel id.
+	knownSpentBucket = []byte("channel-known-spent")
+)
+
+// MarkKnownSpent marks a channel as known to having been spent (i.e. closed)
+// on-chain.
+func (c *ChannelGraph) MarkKnownSpent(channelID uint64) error {
+	return kvdb.Update(c.db, func(tx kvdb.RwTx) error {
+		index, err := tx.CreateTopLevelBucket(knownSpentBucket)
+		if err != nil {
+			return err
+		}
+		var k [8]byte
+		var v [1]byte = [1]byte{0x00}
+		byteOrder.PutUint64(k[:], channelID)
+		return index.Put(k[:], v[:])
+	})
+}
+
+// IsKnownSpent returns if the channel is known to be spent on-chain.
+func (c *ChannelGraph) IsKnownSpent(channelID uint64) (bool, error) {
+	var knownSpent bool
+	err := kvdb.View(c.db, func(tx kvdb.RTx) error {
+		index := tx.ReadBucket(knownSpentBucket)
+		if index == nil {
+			return nil
+		}
+
+		var k [8]byte
+		byteOrder.PutUint64(k[:], channelID)
+		v := index.Get(k[:])
+		knownSpent = len(v) > 0 && v[0] == 0x00
+		return nil
+	})
+
+	return knownSpent, err
+}

--- a/channeldb/graph_extended.go
+++ b/channeldb/graph_extended.go
@@ -43,3 +43,21 @@ func (c *ChannelGraph) IsKnownSpent(channelID uint64) (bool, error) {
 
 	return knownSpent, err
 }
+
+// LocalOpenChanIDs returns a map of channel IDs of all open channels in the
+// local DB.
+func (c *ChannelGraph) LocalOpenChanIDs() (map[uint64]struct{}, error) {
+	// Note: this is less efficient than it could be, because it iterates
+	// through the entire list of channels and then discards all that just
+	// to extract the channel id. In the future, decode that field directly.
+	openChans, err := c.db.FetchAllOpenChannels()
+	if err != nil {
+		return nil, err
+	}
+
+	res := make(map[uint64]struct{}, len(openChans))
+	for _, c := range openChans {
+		res[c.ShortChanID().ToUint64()] = struct{}{}
+	}
+	return res, nil
+}

--- a/lnwallet/errors.go
+++ b/lnwallet/errors.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v4"
+	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrlnd/lnwire"
 )
 
@@ -196,4 +197,26 @@ type ErrUnknownHtlcIndex struct {
 func (e ErrUnknownHtlcIndex) Error() string {
 	return fmt.Sprintf("No HTLC with ID %d in channel %v",
 		e.index, e.chanID)
+}
+
+// ErrUtxoAlreadySpent may be returned by BlockChainIO implementations when a
+// GetUtxo call fails due to the output having been spent.
+type ErrUtxoAlreadySpent struct {
+	PrevOutPoint     wire.OutPoint
+	BlockHeight      int32
+	BlockHash        chainhash.Hash
+	TxIndex          int32
+	SpendingOutPoint wire.OutPoint
+}
+
+// Error returns an error string.
+func (err ErrUtxoAlreadySpent) Error() string {
+	return fmt.Sprintf("UTXO %s already spent by tx %s",
+		err.PrevOutPoint, err.SpendingOutPoint)
+}
+
+// Is is part of the error unwrapping contract.
+func (err ErrUtxoAlreadySpent) Is(target error) bool {
+	var e ErrUtxoAlreadySpent
+	return errors.As(target, &e)
 }

--- a/lnwallet/errors_test.go
+++ b/lnwallet/errors_test.go
@@ -1,0 +1,22 @@
+package lnwallet
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrUtxoAlreadySpent(t *testing.T) {
+	err1 := ErrUtxoAlreadySpent{
+		PrevOutPoint:     wire.OutPoint{Hash: chainhash.Hash{0: 0x01}, Index: 1},
+		SpendingOutPoint: wire.OutPoint{Hash: chainhash.Hash{0: 0x02}, Index: 2},
+	}
+	require.True(t, errors.Is(err1, ErrUtxoAlreadySpent{}))
+	var err2 ErrUtxoAlreadySpent
+	require.True(t, errors.As(err1, &err2))
+	require.Equal(t, err1, err2)
+
+}

--- a/routing/router.go
+++ b/routing/router.go
@@ -2387,6 +2387,12 @@ func (r *ChannelRouter) IsKnownEdge(chanID lnwire.ShortChannelID) bool {
 func (r *ChannelRouter) IsStaleEdgePolicy(chanID lnwire.ShortChannelID,
 	timestamp time.Time, flags lnwire.ChanUpdateChanFlags) bool {
 
+	// If the channel is known to be spent, this can't possibly be a useful
+	// ChannelUpdate.
+	if isSpent, _ := r.cfg.Graph.IsKnownSpent(chanID.ToUint64()); isSpent {
+		return false
+	}
+
 	edge1Timestamp, edge2Timestamp, exists, isZombie, err :=
 		r.cfg.Graph.HasChannelEdge(chanID.ToUint64())
 	if err != nil {


### PR DESCRIPTION
This improves handling of channel announcements and updates for channels that have been closed.

It's been observed on mainnet that some channels that have been closed on-chain are still being announced on the network. This is being caused by the previous channel owners having an entry of the channel in their graph database. While the root cause of this hasn't been determined, this PR attempts to improve things on both source and remote nodes, specially for nodes running in SPV mode.

This PR introduces a new index to track channels that are determined to be closed by GetUtxo calls, and makes use of this index to reduce the need to keep validating channel annoucements. This is also used for channel updates.

An additional check is added to the recurring channel annoucement retransmission, to verify that the channels are indeed open before signing fresh updates, in order to reduce the likelihood of sending spurious updates.
