### PR TITLE
multi: Check invoice receive capacity in milli-atoms

### DIFF
--- a/cmd/dcrlncli/cmd_invoice.go
+++ b/cmd/dcrlncli/cmd_invoice.go
@@ -35,11 +35,11 @@ var addInvoiceCommand = cli.Command{
 		},
 		cli.Int64Flag{
 			Name:  "amt",
-			Usage: "The amt of atoms in this invoice",
+			Usage: "The amount of atoms in this invoice",
 		},
 		cli.Int64Flag{
-			Name:  "amt_msat",
-			Usage: "the amt of millisatoshis in this invoice",
+			Name:  "amt_matoms",
+			Usage: "The amount of milliatoms in this invoice",
 		},
 		cli.StringFlag{
 			Name: "description_hash",
@@ -96,8 +96,8 @@ func addInvoice(ctx *cli.Context) error {
 	args := ctx.Args()
 
 	amt = ctx.Int64("amt")
-	amtMAtoms = ctx.Int64("amt_msat")
-	if !ctx.IsSet("amt") && !ctx.IsSet("amt_msat") && args.Present() {
+	amtMAtoms = ctx.Int64("amt_matoms")
+	if !ctx.IsSet("amt") && !ctx.IsSet("amt_matoms") && args.Present() {
 		amt, err = strconv.ParseInt(args.First(), 10, 64)
 		args = args.Tail()
 		if err != nil {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4954,6 +4954,12 @@ func (r *rpcServer) checkCanReceiveInvoice(ctx context.Context,
 	}
 
 	amt := dcrutil.Amount(invoice.Value)
+	if invoice.ValueMAtoms != 0 {
+		amt = dcrutil.Amount(invoice.ValueMAtoms / 1000)
+		if invoice.ValueMAtoms%1000 > 0 {
+			amt += 1
+		}
+	}
 
 	// Loop through all available channels, check for liveliness and capacity.
 	var maxInbound dcrutil.Amount


### PR DESCRIPTION
Previously, this was checked only when the invoice was specified for atoms.

