### PR TITLE
channeldb: Fix migration 20 incorrect outpoint serialization

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -27,7 +27,7 @@ const (
 const (
 	appMajor uint = 0
 	appMinor uint = 5
-	appPatch uint = 0
+	appPatch uint = 1
 )
 
 var (

--- a/channeldb/codec.go
+++ b/channeldb/codec.go
@@ -25,6 +25,8 @@ func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
 	if err := binary.Write(w, byteOrder, o.Index); err != nil {
 		return err
 	}
+
+	// Note: this is decred-only.
 	if err := binary.Write(w, byteOrder, o.Tree); err != nil {
 		return err
 	}
@@ -41,6 +43,8 @@ func readOutpoint(r io.Reader, o *wire.OutPoint) error {
 	if err := binary.Read(r, byteOrder, &o.Index); err != nil {
 		return err
 	}
+
+	// Note: this is decred-only.
 	if err := binary.Read(r, byteOrder, &o.Tree); err != nil {
 		return err
 	}

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -1262,6 +1262,12 @@ func (d *DB) syncVersions(versions []version) error {
 		// In dry-run mode, return an error to prevent the transaction
 		// from committing.
 		if d.dryRun {
+			// In dry run mode, also attempt dcrlnd migrations
+			// before stopping.
+			if err := d.syncDcrlndDBVersions(tx); err != nil {
+				return err
+			}
+
 			return ErrDryRunMigrationOK
 		}
 

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -195,6 +195,10 @@ var (
 			number:    22,
 			migration: mig.CreateTLB(setIDIndexBucket),
 		},
+		// Note: There are decred-only changes in the codec which may
+		// require porting when bringing upstream migrations from lnd.
+		// In particular:
+		// - {read,write}Outpoint include the tree.
 	}
 
 	// Big endian is the preferred byte order, due to cursor scans over

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -34,7 +34,7 @@ func TestOpenWithCreate(t *testing.T) {
 
 	// Next, open thereby creating channeldb for the first time.
 	dbPath := filepath.Join(tempDirName, "cdb")
-	backend, cleanup, err := kvdb.GetTestBackend(dbPath, "cdb")
+	backend, cleanup, err := kvdb.GetTestBackend(dbPath, dbName)
 	if err != nil {
 		t.Fatalf("unable to get test db backend: %v", err)
 	}

--- a/channeldb/dcrdb.go
+++ b/channeldb/dcrdb.go
@@ -1,10 +1,118 @@
 package channeldb
 
-import "github.com/decred/dcrlnd/kvdb"
+import (
+	dcrmigration01 "github.com/decred/dcrlnd/channeldb/dcrmigrations/migration01"
+	"github.com/decred/dcrlnd/kvdb"
+)
+
+var (
+	dcrMetaBucket = []byte("dcrlnd_metadata")
+)
+
+var (
+	// dcrDbVersions are the decred-only migrations.
+	dcrDbVersions = []version{
+		{number: 1, migration: dcrmigration01.FixMigration20},
+	}
+)
+
+// latestDcrDbVersion returns the latest version of the decred-specific db
+// migrations.
+func latestDcrDbVersion() uint32 {
+	return dcrDbVersions[len(dcrDbVersions)-1].number
+}
+
+// applyDecredMigations applies the decred-only migrations.
+func (d *DB) applyDecredMigations(tx kvdb.RwTx, dbVersion uint32) error {
+	latestVersion := dcrDbVersions[len(dcrDbVersions)-1].number
+	log.Infof("Checking for decred-specicic migrations latest_version=%d, "+
+		"db_version=%d", latestVersion, dbVersion)
+
+	if latestVersion < dbVersion {
+		log.Errorf("Refusing to revert from decred db_version=%d to "+
+			"lower version=%d", dbVersion, latestVersion)
+		return ErrDBReversion
+	}
+
+	if latestVersion == dbVersion {
+		// Nothing to do.
+		return nil
+	}
+
+	log.Infof("Performing decred-specific database schema migration")
+
+	metaBucket := tx.ReadWriteBucket(dcrMetaBucket)
+	for _, mig := range dcrDbVersions {
+		if mig.migration == nil {
+			continue
+		}
+		if mig.number <= dbVersion {
+			continue
+		}
+
+		log.Infof("Applying migration #%d", mig.number)
+
+		if err := mig.migration(tx); err != nil {
+			log.Infof("Unable to apply migration #%d",
+				mig.number)
+			return err
+		}
+
+		// Save the new db version.
+		dbVersion = mig.number
+		err := metaBucket.Put(dbVersionKey, byteOrder.AppendUint32(nil, dbVersion))
+		if err != nil {
+			return err
+		}
+	}
+
+	// Stop if running in dry-run mode.
+	if d.dryRun {
+		return ErrDryRunMigrationOK
+	}
+
+	return nil
+}
+
+// syncDcrlndDBVersions performs the dcrlnd-specific db upgrades.
+func (d *DB) syncDcrlndDBVersions(tx kvdb.RwTx) error {
+	// Read dcr-specific version.
+	var dbVersion uint32
+	bucket := tx.ReadWriteBucket(dcrMetaBucket)
+	if bucket == nil {
+		// Filled meta bucket but empty dcr-specific meta bucket.
+		// Create dcr one.
+		var err error
+		bucket, err = tx.CreateTopLevelBucket(dcrMetaBucket)
+		if err != nil {
+			return err
+		}
+
+		// If the global meta bucket is empty, it's a new db.
+		if tx.ReadBucket(metaBucket) == nil {
+			dbVersion = latestDcrDbVersion()
+		}
+
+		// dbVersion == 0.
+		bucket.Put(dbVersionKey, byteOrder.AppendUint32(nil, dbVersion))
+	} else {
+		v := bucket.Get(dbVersionKey)
+		if v != nil {
+			dbVersion = byteOrder.Uint32(v)
+		}
+	}
+
+	// Apply dcr-specific migrations.
+	return d.applyDecredMigations(tx, dbVersion)
+}
 
 // initDcrlndFeatures initializes features that are specific to dcrlnd.
-func (db *DB) initDcrlndFeatures() error {
-	return kvdb.Update(db, func(tx kvdb.RwTx) error {
+func (d *DB) initDcrlndFeatures() error {
+	return kvdb.Update(d, func(tx kvdb.RwTx) error {
+		if err := d.syncDcrlndDBVersions(tx); err != nil {
+			return err
+		}
+
 		// If the inflight payments index bucket doesn't exist,
 		// initialize it.
 		indexBucket := tx.ReadWriteBucket(paymentsInflightIndexBucket)

--- a/channeldb/dcrmigrations/migration01/codec.go
+++ b/channeldb/dcrmigrations/migration01/codec.go
@@ -1,0 +1,48 @@
+package dcrmigration01
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/decred/dcrd/wire"
+)
+
+// readMig20Outpoint reads an outpoint that was stored by the migration20.
+func readMig20Outpoint(r io.Reader, o *wire.OutPoint) error {
+	if _, err := io.ReadFull(r, o.Hash[:]); err != nil {
+		return err
+	}
+	if err := binary.Read(r, byteOrder, &o.Index); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeMig20Outpoint writes an outpoint from the passed writer.
+func writeMig20Outpoint(w io.Writer, o *wire.OutPoint) error {
+	if _, err := w.Write(o.Hash[:]); err != nil {
+		return err
+	}
+	if err := binary.Write(w, byteOrder, o.Index); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeOkOutpoint writes an outpoint with the correct format to the passed
+// writer.
+func writeOkOutpoint(w io.Writer, o *wire.OutPoint) error {
+	if _, err := w.Write(o.Hash[:]); err != nil {
+		return err
+	}
+	if err := binary.Write(w, byteOrder, o.Index); err != nil {
+		return err
+	}
+	if err := binary.Write(w, byteOrder, o.Tree); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/channeldb/dcrmigrations/migration01/dcrmigration01.go
+++ b/channeldb/dcrmigrations/migration01/dcrmigration01.go
@@ -1,0 +1,77 @@
+package dcrmigration01
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrlnd/kvdb"
+)
+
+var (
+	byteOrder = binary.BigEndian
+
+	// outpointBucket is an index mapping outpoints to a tlv
+	// stream of channel data.
+	outpointBucket = []byte("outpoint-bucket")
+)
+
+// FixMigration20 fixes a version of the version 20 that had a wrong
+// implementation for the writeOutpoint codec function. This assumes that
+// migration20 was executed and now needs to be fixed.
+func FixMigration20(tx kvdb.RwTx) error {
+	// Get the target bucket.
+	bucket := tx.ReadWriteBucket(outpointBucket)
+
+	// Collect the data that needs migration.
+	var keys []*wire.OutPoint
+	values := map[*wire.OutPoint][]byte{}
+	err := bucket.ForEach(func(k, v []byte) error {
+		op := new(wire.OutPoint)
+		r := bytes.NewReader(k)
+		if err := readMig20Outpoint(r, op); err != nil {
+			return err
+		}
+
+		keys = append(keys, op)
+		switch {
+		case v == nil:
+			values[op] = nil
+		case len(v) == 0:
+			values[op] = []byte{}
+		default:
+			values[op] = append([]byte(nil), v...)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Migrating %d entries", len(keys))
+
+	for _, op := range keys {
+		log.Debugf("Migrating outpoint %s", op)
+
+		var oldOpBuf bytes.Buffer
+		if err := writeMig20Outpoint(&oldOpBuf, op); err != nil {
+			return err
+		}
+
+		if err := bucket.Delete(oldOpBuf.Bytes()); err != nil {
+			return err
+		}
+
+		var newOpBuf bytes.Buffer
+		if err := writeOkOutpoint(&newOpBuf, op); err != nil {
+			return err
+		}
+		value := values[op]
+		if err := bucket.Put(newOpBuf.Bytes(), value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/channeldb/dcrmigrations/migration01/dcrmigration01_test.go
+++ b/channeldb/dcrmigrations/migration01/dcrmigration01_test.go
@@ -1,0 +1,45 @@
+package dcrmigration01
+
+import (
+	"testing"
+
+	"github.com/decred/dcrlnd/channeldb/migtest"
+	"github.com/decred/dcrlnd/kvdb"
+)
+
+var (
+	hexStr = migtest.Hex
+
+	tlvOutpointOpen   = hexStr("000100")
+	tlvOutpointClosed = hexStr("000101")
+
+	outpointMig20     = hexStr("81b637d8fcd2c6da6859e6963113a1170de793e4b725b84d1e0b4cf99ec58ce952d6c6c7")
+	outpointMig20_2   = hexStr("abb637d8fcd2c6da6859e6963113a1170de793e4b725b84d1e0b4cf99ec58ce952d6c6c7")
+	outpointDataMig20 = map[string]interface{}{
+		outpointMig20:   tlvOutpointOpen,
+		outpointMig20_2: tlvOutpointClosed,
+	}
+
+	outpointCorrect     = hexStr("81b637d8fcd2c6da6859e6963113a1170de793e4b725b84d1e0b4cf99ec58ce952d6c6c700")
+	outpointCorrect_2   = hexStr("abb637d8fcd2c6da6859e6963113a1170de793e4b725b84d1e0b4cf99ec58ce952d6c6c700")
+	outpointDataCorrect = map[string]interface{}{
+		outpointCorrect:   tlvOutpointOpen,
+		outpointCorrect_2: tlvOutpointClosed,
+	}
+)
+
+func TestFixMigration20(t *testing.T) {
+	// Prime the database with the results of migration20 (wrong outpoint
+	// key).
+	before := func(tx kvdb.RwTx) error {
+		return migtest.RestoreDB(tx, outpointBucket, outpointDataMig20)
+	}
+
+	// Double check the keys were migrated to use the correct serialization
+	// of outpoint.
+	after := func(tx kvdb.RwTx) error {
+		return migtest.VerifyDB(tx, outpointBucket, outpointDataCorrect)
+	}
+
+	migtest.ApplyMigration(t, before, after, FixMigration20, false)
+}

--- a/channeldb/dcrmigrations/migration01/log.go
+++ b/channeldb/dcrmigrations/migration01/log.go
@@ -1,0 +1,14 @@
+package dcrmigration01
+
+import (
+	"github.com/decred/slog"
+)
+
+// log is a logger that is initialized as disabled. This means the package
+// will not perform any logging by default until a logger is set.
+var log = slog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/channeldb/log.go
+++ b/channeldb/log.go
@@ -2,6 +2,7 @@ package channeldb
 
 import (
 	"github.com/decred/dcrlnd/build"
+	dcrmigration01 "github.com/decred/dcrlnd/channeldb/dcrmigrations/migration01"
 	mig "github.com/decred/dcrlnd/channeldb/migration"
 	"github.com/decred/dcrlnd/channeldb/migration12"
 	"github.com/decred/dcrlnd/channeldb/migration13"
@@ -39,4 +40,6 @@ func UseLogger(logger slog.Logger) {
 	migration16.UseLogger(logger)
 	migration20.UseLogger(logger)
 	kvdb.UseLogger(logger)
+
+	dcrmigration01.UseLogger(logger)
 }

--- a/channeldb/log.go
+++ b/channeldb/log.go
@@ -6,6 +6,7 @@ import (
 	"github.com/decred/dcrlnd/channeldb/migration12"
 	"github.com/decred/dcrlnd/channeldb/migration13"
 	"github.com/decred/dcrlnd/channeldb/migration16"
+	"github.com/decred/dcrlnd/channeldb/migration20"
 	"github.com/decred/dcrlnd/channeldb/migration_01_to_11"
 	"github.com/decred/dcrlnd/kvdb"
 	"github.com/decred/slog"
@@ -36,5 +37,6 @@ func UseLogger(logger slog.Logger) {
 	migration12.UseLogger(logger)
 	migration13.UseLogger(logger)
 	migration16.UseLogger(logger)
+	migration20.UseLogger(logger)
 	kvdb.UseLogger(logger)
 }

--- a/channeldb/migration20/codec.go
+++ b/channeldb/migration20/codec.go
@@ -20,6 +20,8 @@ func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
 		return err
 	}
 
+	// Note(decred): This is missing the tree.
+
 	return nil
 }
 
@@ -31,6 +33,8 @@ func readOutpoint(r io.Reader, o *wire.OutPoint) error {
 	if err := binary.Read(r, byteOrder, &o.Index); err != nil {
 		return err
 	}
+
+	// Note(decred): This is missing the tree.
 
 	return nil
 }

--- a/channeldb/migration20/migration.go
+++ b/channeldb/migration20/migration.go
@@ -59,6 +59,8 @@ func MigrateOutpointIndex(tx kvdb.RwTx) error {
 		return err
 	}
 
+	log.Infof("Found %d open %d closed", len(openList), len(closedList))
+
 	// Get the outpoint bucket which was created in migration 19.
 	bucket := tx.ReadWriteBucket(outpointBucket)
 
@@ -90,6 +92,7 @@ func getOpenOutpoints(tx kvdb.RwTx) ([]*wire.OutPoint, error) {
 		// Ensure that the key is the same size as a pubkey and the
 		// value is nil.
 		if len(k) != 33 || v != nil {
+			log.Warnf("key not 33 bytes (%x)", k)
 			return nil
 		}
 
@@ -101,6 +104,7 @@ func getOpenOutpoints(tx kvdb.RwTx) ([]*wire.OutPoint, error) {
 		return nodeBucket.ForEach(func(k, v []byte) error {
 			// If there's a value it's not a bucket.
 			if v != nil {
+				log.Warnf("key not a bucket: %x", k)
 				return nil
 			}
 
@@ -113,6 +117,7 @@ func getOpenOutpoints(tx kvdb.RwTx) ([]*wire.OutPoint, error) {
 			return chainBucket.ForEach(func(k, v []byte) error {
 				// If there's a value it's not a bucket.
 				if v != nil {
+					log.Warnf("entry in chainBucket not a bucket: %x", k)
 					return nil
 				}
 
@@ -123,6 +128,8 @@ func getOpenOutpoints(tx kvdb.RwTx) ([]*wire.OutPoint, error) {
 				}
 
 				ops = append(ops, &op)
+
+				log.Infof("Appending as open channel %s", op)
 
 				return nil
 			})

--- a/channeldb/migration21/current/current_codec.go
+++ b/channeldb/migration21/current/current_codec.go
@@ -31,6 +31,8 @@ func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
 	if err := binary.Write(w, byteOrder, o.Index); err != nil {
 		return err
 	}
+
+	// Note: this is decred-only.
 	if err := binary.Write(w, byteOrder, o.Tree); err != nil {
 		return err
 	}
@@ -47,6 +49,8 @@ func readOutpoint(r io.Reader, o *wire.OutPoint) error {
 	if err := binary.Read(r, byteOrder, &o.Index); err != nil {
 		return err
 	}
+
+	// Note: this is decred-only.
 	if err := binary.Read(r, byteOrder, &o.Tree); err != nil {
 		return err
 	}

--- a/channeldb/migration21/legacy/legacy_codec.go
+++ b/channeldb/migration21/legacy/legacy_codec.go
@@ -30,6 +30,8 @@ func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
 	if err := binary.Write(w, byteOrder, o.Index); err != nil {
 		return err
 	}
+
+	// Note: this is decred-only.
 	if err := binary.Write(w, byteOrder, o.Tree); err != nil {
 		return err
 	}
@@ -46,6 +48,8 @@ func readOutpoint(r io.Reader, o *wire.OutPoint) error {
 	if err := binary.Read(r, byteOrder, &o.Index); err != nil {
 		return err
 	}
+
+	// Note: this is decred-only.
 	if err := binary.Read(r, byteOrder, &o.Tree); err != nil {
 		return err
 	}

--- a/channeldb/migration_01_to_11/codec.go
+++ b/channeldb/migration_01_to_11/codec.go
@@ -24,6 +24,8 @@ func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
 	if err := binary.Write(w, byteOrder, o.Index); err != nil {
 		return err
 	}
+
+	// Note: this is decred-only.
 	if err := binary.Write(w, byteOrder, o.Tree); err != nil {
 		return err
 	}
@@ -40,6 +42,8 @@ func readOutpoint(r io.Reader, o *wire.OutPoint) error {
 	if err := binary.Read(r, byteOrder, &o.Index); err != nil {
 		return err
 	}
+
+	// Note: this is decred-only.
 	if err := binary.Read(r, byteOrder, &o.Tree); err != nil {
 		return err
 	}

--- a/docs/release-notes/release-notes-0.5.1.md
+++ b/docs/release-notes/release-notes-0.5.1.md
@@ -1,0 +1,20 @@
+# dcrlnd v0.5.1
+
+
+## Database Migrations
+
+This release contains a [database
+migration](https://github.com/decred/dcrlnd/pull/203) that fixes an issue
+introduced by a prior migration (migration 20) ported from upstream lnd. This
+issue could cause channels that were opened before v0.5.0 of the software to not
+be properly closed (or detected as closed), causing affected channels to still
+be listed as opened.
+
+## Various New Features
+
+Added the [rescan wallet](https://github.com/decred/dcrlnd/pull/198) 
+
+## Dependencies Updates
+
+Updated [dcrwallet](https://github.com/decred/dcrlnd/pull/202) to the latest
+version of the v1.8 release line.

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -41,9 +41,11 @@ var (
 	byteOrder = binary.BigEndian
 )
 
-// WriteOutpoint writes an outpoint to an io.Writer. This is not the same as
+// writeOutpoint writes an outpoint to an io.Writer. This is not the same as
 // the channeldb variant as this uses WriteVarBytes for the Hash.
-func WriteOutpoint(w io.Writer, o *wire.OutPoint) error {
+//
+// Note(decred): This does not include the Tree field of the outpoint.
+func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
 	scratch := make([]byte, 4)
 
 	if err := wire.WriteVarBytes(w, 0, o.Hash[:]); err != nil {
@@ -52,6 +54,9 @@ func WriteOutpoint(w io.Writer, o *wire.OutPoint) error {
 
 	byteOrder.PutUint32(scratch, o.Index)
 	_, err := w.Write(scratch)
+
+	// Note(decred): this does not include the Tree field of the outpoint.
+
 	return err
 }
 
@@ -3551,7 +3556,7 @@ func (f *Manager) saveChannelOpeningState(chanPoint *wire.OutPoint,
 		}
 
 		var outpointBytes bytes.Buffer
-		if err = WriteOutpoint(&outpointBytes, chanPoint); err != nil {
+		if err = writeOutpoint(&outpointBytes, chanPoint); err != nil {
 			return err
 		}
 
@@ -3583,7 +3588,7 @@ func (f *Manager) getChannelOpeningState(chanPoint *wire.OutPoint) (
 		}
 
 		var outpointBytes bytes.Buffer
-		if err := WriteOutpoint(&outpointBytes, chanPoint); err != nil {
+		if err := writeOutpoint(&outpointBytes, chanPoint); err != nil {
 			return err
 		}
 
@@ -3612,7 +3617,7 @@ func (f *Manager) deleteChannelOpeningState(chanPoint *wire.OutPoint) error {
 		}
 
 		var outpointBytes bytes.Buffer
-		if err := WriteOutpoint(&outpointBytes, chanPoint); err != nil {
+		if err := writeOutpoint(&outpointBytes, chanPoint); err != nil {
 			return err
 		}
 

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -1424,6 +1424,9 @@ func (k *kidOutput) Decode(r io.Reader) error {
 }
 
 // TODO(bvu): copied from channeldb, remove repetition
+//
+// Note(decred): this cannot be moved to use the channeldb version because it
+// does not include the outpoint's tree field.
 func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
 	// TODO(roasbeef): make all scratch buffers on the stack
 	scratch := make([]byte, 4)
@@ -1436,10 +1439,15 @@ func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
 
 	byteOrder.PutUint32(scratch, o.Index)
 	_, err := w.Write(scratch)
+
+	// Note(decred): this does not include the Tree field
 	return err
 }
 
 // TODO(bvu): copied from channeldb, remove repetition
+//
+// Note(decred): this cannot be moved to use the channeldb version because it
+// does not include the outpoint's tree field.
 func readOutpoint(r io.Reader, o *wire.OutPoint) error {
 	scratch := make([]byte, 4)
 
@@ -1454,6 +1462,7 @@ func readOutpoint(r io.Reader, o *wire.OutPoint) error {
 	}
 	o.Index = byteOrder.Uint32(scratch)
 
+	// Note(decred): this does not include the Tree field
 	return nil
 }
 


### PR DESCRIPTION
This migration fixes the prior migration 20, introduced when porting the upstream code.

That migration erroneously encoded outpoints without the Tree field that exists in decred code, thus rendering the index incorrect.

The new migration corrects the issue by assuming the tree of every entry is zero, which is true because the channels can only reside in regular (as opposed to stake) transactions.

One way this could cause problems was when closing or detecting closed channels that were created before the migration took place. Closing them could fail with "missing outpoint from index".

While this fixes the issue for nodes that upgrade, this does not handle channels that were already closed for nodes that are already running v0.5.0.