### PR TITLE
peer: Use a dedicated ping logger

### DIFF
--- a/log.go
+++ b/log.go
@@ -139,6 +139,7 @@ func SetupLoggers(root *build.RotatingLogWriter, interceptor signal.Interceptor)
 	AddSubLogger(root, "AUTO", interceptor, automation.UseLogger)
 	AddSubLogger(root, "PGDB", interceptor, postgres.UseLogger)
 	AddSubLogger(root, "LCCH", interceptor, localchans.UseLogger)
+	AddSubLogger(root, "PING", interceptor, peer.UsePingLogger)
 
 	AddSubLogger(root, "LNWL", interceptor, lnwallet.UseLogger)
 	AddSubLogger(root, "DISC", interceptor, discovery.UseLogger)

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1753,7 +1753,13 @@ func (p *Brontide) logWireMessage(msg lnwire.Message, read bool) {
 		summaryPrefix = "Sending"
 	}
 
-	peerLog.Debugf("%v", newLogClosure(func() string {
+	logger := peerLog
+	switch msg.(type) {
+	case *lnwire.Ping, *lnwire.Pong:
+		logger = pingLog
+	}
+
+	logger.Debugf("%v", newLogClosure(func() string {
 		// Debug summary of message.
 		summary := messageSummary(msg)
 		if len(summary) > 0 {
@@ -1781,7 +1787,7 @@ func (p *Brontide) logWireMessage(msg lnwire.Message, read bool) {
 		prefix = "writeMessage to"
 	}
 
-	peerLog.Tracef(prefix+" %v: %v", p, newLogClosure(func() string {
+	logger.Tracef(prefix+" %v: %v", p, newLogClosure(func() string {
 		return spew.Sdump(msg)
 	}))
 }

--- a/peer/log.go
+++ b/peer/log.go
@@ -8,19 +8,29 @@ import (
 // peerLog is a logger that is initialized with the slog.Disabled logger.
 var peerLog slog.Logger
 
+// pingLog is a logger that is used to log sent and received ping/pong
+// messages.
+var pingLog slog.Logger
+
 // The default amount of logging is none.
 func init() {
 	UseLogger(build.NewSubLogger("PEER", nil))
+	UseLogger(build.NewSubLogger("PING", nil))
 }
 
 // DisableLog disables all logging output.
 func DisableLog() {
 	UseLogger(slog.Disabled)
+	UsePingLogger(slog.Disabled)
 }
 
 // UseLogger uses a specified Logger to output package logging info.
 func UseLogger(logger slog.Logger) {
 	peerLog = logger
+}
+
+func UsePingLogger(logger slog.Logger) {
+	pingLog = logger
 }
 
 // logClosure is used to provide a closure over expensive logging operations


### PR DESCRIPTION
This switches the peer to log ping/pong messages using a separate logger with a dedicated subsystem tag. This is useful when running in debug mode for extended periods of time, as ping messages are generally useless but repeat constantly, needlessly growing the size of log files and making debug harder.

