### PR TITLE
Fix gossip timestamps set to a future date

### DIFF
--- a/channeldb/dcrdb.go
+++ b/channeldb/dcrdb.go
@@ -2,6 +2,7 @@ package channeldb
 
 import (
 	dcrmigration01 "github.com/decred/dcrlnd/channeldb/dcrmigrations/migration01"
+	dcrmigration02 "github.com/decred/dcrlnd/channeldb/dcrmigrations/migration02"
 	"github.com/decred/dcrlnd/kvdb"
 )
 
@@ -13,6 +14,7 @@ var (
 	// dcrDbVersions are the decred-only migrations.
 	dcrDbVersions = []version{
 		{number: 1, migration: dcrmigration01.FixMigration20},
+		{number: 2, migration: dcrmigration02.RemoveFutureTimestampFromPeers},
 	}
 )
 

--- a/channeldb/dcrmigrations/migration02/dcrmigration02.go
+++ b/channeldb/dcrmigrations/migration02/dcrmigration02.go
@@ -1,0 +1,119 @@
+package dcrmigration02
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"time"
+
+	"github.com/decred/dcrlnd/kvdb"
+)
+
+const (
+	// pastOffsetFix is how much to rewind the date of the last gossip
+	// timestamp from now.
+	pastOffsetFix = time.Hour * 72
+)
+
+var (
+	// peersBucket is the key for the bucket that holds per-gossip-peer
+	// info.
+	peersBucket = []byte("peers-bucket")
+
+	// peerLastGossipMsgTSKey is the key for a value in the peer bucket that
+	// tracks the unix timestamp of the last received gossip message
+	// (ChannelUpdate, ChannelAnnouncement, NodeAnnounce).
+	peerLastGossipMsgTSKey = []byte("last-gossip-msg-ts")
+
+	// Big endian is the preferred byte order, due to cursor scans over
+	// integer keys iterating in order.
+	byteOrder = binary.BigEndian
+
+	// nowFunc is modified during tests to ensure a consistent now.
+	nowFunc = time.Now
+)
+
+// deserializeTime deserializes time as unix nanoseconds.
+func deserializeTime(r io.Reader) (time.Time, error) {
+	var scratch [8]byte
+	if _, err := io.ReadFull(r, scratch[:]); err != nil {
+		return time.Time{}, err
+	}
+
+	// Convert to time.Time. Interpret unix nano time zero as a zero
+	// time.Time value.
+	unixNano := byteOrder.Uint64(scratch[:])
+	if unixNano == 0 {
+		return time.Time{}, nil
+	}
+
+	return time.Unix(0, int64(unixNano)), nil
+}
+
+// serializeTime serializes time as unix nanoseconds.
+func serializeTime(w io.Writer, t time.Time) error {
+	var scratch [8]byte
+
+	// Convert to unix nano seconds, but only if time is non-zero. Calling
+	// UnixNano() on a zero time yields an undefined result.
+	var unixNano int64
+	if !t.IsZero() {
+		unixNano = t.UnixNano()
+	}
+
+	byteOrder.PutUint64(scratch[:], uint64(unixNano))
+	_, err := w.Write(scratch[:])
+	return err
+}
+
+// RemoveFutureTimestampFromPeers fixes a bug that caused the db to store
+// a future date as the latest timestamp for gossip messages, causing the peer
+// to fail to request gossip updates.
+func RemoveFutureTimestampFromPeers(tx kvdb.RwTx) error {
+	// If the timestamp is in the future, set it as 72h in the past to
+	// ensure we get any new channel updates.
+	now := nowFunc()
+	newTs := now.Add(-pastOffsetFix)
+
+	var b bytes.Buffer
+	err := serializeTime(&b, newTs)
+	if err != nil {
+		return err
+	}
+
+	// Get the target bucket.
+	var migrated int
+	bucket := tx.ReadWriteBucket(peersBucket)
+	err = bucket.ForEach(func(k, v []byte) error {
+		peerBucket := bucket.NestedReadWriteBucket(k)
+		if peerBucket == nil {
+			return nil
+		}
+
+		tsBytes := peerBucket.Get(peerLastGossipMsgTSKey)
+		if tsBytes == nil {
+			return nil
+		}
+
+		ts, err := deserializeTime(bytes.NewReader(tsBytes))
+		if err != nil {
+			return nil
+		}
+
+		if !ts.After(now) {
+			return nil
+		}
+
+		// Entry needs to be migrated.
+		migrated++
+		return peerBucket.Put(peerLastGossipMsgTSKey, b.Bytes())
+	})
+
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Migrated %d future timestamps to %s", migrated,
+		newTs.Format(time.RFC3339))
+	return nil
+}

--- a/channeldb/dcrmigrations/migration02/dcrmigration02_test.go
+++ b/channeldb/dcrmigrations/migration02/dcrmigration02_test.go
@@ -1,0 +1,59 @@
+package dcrmigration02
+
+import (
+	"testing"
+	"time"
+
+	"github.com/decred/dcrlnd/channeldb/migtest"
+	"github.com/decred/dcrlnd/kvdb"
+)
+
+var (
+	hexStr    = migtest.Hex
+	mockNow   = time.Unix(1711465236, 0)
+	wantNewTs = mockNow.Add(-pastOffsetFix)
+
+	pub01 = hexStr("032195e05c87bf05b4fe34d7f2dd629390460e44fceab1f48252878d79dafa5779")
+	pub02 = hexStr("027e8c63c6eb86cd3bf64f58d6a86539bab58a1c25a9bc8c9e01e0a938e7b19821")
+	pub03 = hexStr("020ed7807b8e384df0cdaa3ef89f71e0ffc68a67df69c7674d24fe2896ff7ee8da")
+
+	pastTime           = string(byteOrder.AppendUint64(nil, uint64(time.Unix(1518112800, 0).UnixNano())))
+	futureTime         = string(byteOrder.AppendUint64(nil, uint64(mockNow.Add(time.Second).UnixNano())))
+	futureTimeAfterMig = string(byteOrder.AppendUint64(nil, uint64(wantNewTs.UnixNano())))
+	peersPreMigration  = map[string]interface{}{
+		pub01: map[string]interface{}{
+			string(peerLastGossipMsgTSKey): pastTime,
+		},
+		pub02: map[string]interface{}{
+			string(peerLastGossipMsgTSKey): futureTime,
+		},
+		pub03: map[string]interface{}{}, // Peer without timestamp
+	}
+
+	peersPostMigration = map[string]interface{}{
+		pub01: map[string]interface{}{
+			string(peerLastGossipMsgTSKey): pastTime,
+		},
+		pub02: map[string]interface{}{
+			string(peerLastGossipMsgTSKey): futureTimeAfterMig,
+		},
+		pub03: map[string]interface{}{}, // Peer without timestamp
+	}
+)
+
+func TestRemoveFutureTimestamps(t *testing.T) {
+	// Modify now() to return a mock date.
+	nowFunc = func() time.Time { return mockNow }
+
+	// Prime the database with peer data in the past and future.
+	before := func(tx kvdb.RwTx) error {
+		return migtest.RestoreDB(tx, peersBucket, peersPreMigration)
+	}
+
+	// Double check the future dates were migrated to the past.
+	after := func(tx kvdb.RwTx) error {
+		return migtest.VerifyDB(tx, peersBucket, peersPostMigration)
+	}
+
+	migtest.ApplyMigration(t, before, after, RemoveFutureTimestampFromPeers, false)
+}

--- a/channeldb/dcrmigrations/migration02/log.go
+++ b/channeldb/dcrmigrations/migration02/log.go
@@ -1,0 +1,14 @@
+package dcrmigration02
+
+import (
+	"github.com/decred/slog"
+)
+
+// log is a logger that is initialized as disabled. This means the package
+// will not perform any logging by default until a logger is set.
+var log = slog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/channeldb/log.go
+++ b/channeldb/log.go
@@ -3,6 +3,7 @@ package channeldb
 import (
 	"github.com/decred/dcrlnd/build"
 	dcrmigration01 "github.com/decred/dcrlnd/channeldb/dcrmigrations/migration01"
+	dcrmigration02 "github.com/decred/dcrlnd/channeldb/dcrmigrations/migration02"
 	mig "github.com/decred/dcrlnd/channeldb/migration"
 	"github.com/decred/dcrlnd/channeldb/migration12"
 	"github.com/decred/dcrlnd/channeldb/migration13"
@@ -44,4 +45,5 @@ func UseLogger(logger slog.Logger) {
 	kvdb.UseLogger(logger)
 
 	dcrmigration01.UseLogger(logger)
+	dcrmigration02.UseLogger(logger)
 }

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2122,9 +2122,12 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 		) {
 
 			log.Debugf("Ignored stale edge policy: peer=%v, "+
-				"source=%x, msg=%s, is_remote=%v", nMsg.peer,
+				"source=%x, msg=%s, is_remote=%v, channel=%s, "+
+				"ts=%s", nMsg.peer,
 				nMsg.source.SerializeCompressed(),
-				nMsg.msg.MsgType(), nMsg.isRemote)
+				nMsg.msg.MsgType(), nMsg.isRemote,
+				msg.ShortChannelID,
+				timestamp.Format(time.RFC3339))
 
 			nMsg.err <- nil
 			return nil, true

--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -1251,6 +1251,8 @@ func (g *GossipSyncer) FilterGossipMsgs(msgs ...msgWithSenders) {
 	// If the peer doesn't have an update horizon set, then we won't send
 	// it any new update messages.
 	if g.remoteUpdateHorizon == nil {
+		log.Tracef("GossipSyncer(%x): filtering due to no remoteUpdateHorizon",
+			g.cfg.peerPub[:])
 		return
 	}
 
@@ -1346,6 +1348,14 @@ func (g *GossipSyncer) FilterGossipMsgs(msgs ...msgWithSenders) {
 		case *lnwire.ChannelUpdate:
 			if passesFilter(msg.Timestamp) {
 				msgsToSend = append(msgsToSend, msg)
+			} else {
+				ts := time.Unix(int64(msg.Timestamp), 0)
+				log.Tracef("GossipSyncer(%x): ChannelUpdate does "+
+					"not pass filter chan=%s ts=%s hz_start=%s "+
+					"hz_end=%s", g.cfg.peerPub[:],
+					msg.ShortChannelID, ts.Format(time.RFC3339),
+					startTime.Format(time.RFC3339),
+					endTime.Format(time.RFC3339))
 			}
 
 		// Similarly, we only send node announcements if the update


### PR DESCRIPTION
This fixes an issue in the deployed network where nodes sending ChannelUpdates and NodeAnnouncements set to a future timestamp could cause the gossip syncer to fail to fetch new announcements.

The issue stems from the fact that the gossip syncer stores the timestamp of the last received message and uses that, upon restart, to fetch new messages. An update with a timestamp in the future propagating through the network would cause the syncer to fail to fetch new updates.

This PR fixes the issue by amending the handling of future timestamps in the syncer and by performing a database migration that rewinds any timestamps stored that are set to a future date. 