### PR TITLE
Add release notes for v0.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,13 @@ ITEST_LDFLAGS := -ldflags "-X $(PKG)/build.Commit=$(COMMIT)"
 RELEASE_LDFLAGS := $(call make_ldflags, $(RELEASE_TAGS), -s -w -buildid=)
 
 DCRD_REPO := github.com/decred/dcrd
-DCRD_COMMIT := 3d4d27280b43207c2891b733a3d33fdfb411b555
+DCRD_COMMIT := release-v2.0.0
 DCRD_META := "$(DCRD_COMMIT).from-dcrlnd"
 DCRD_LDFLAGS := "-X github.com/decred/dcrd/internal/version.BuildMetadata=$(DCRD_META)"
 DCRD_TMPDIR := $(shell mktemp -d)
 
 DCRWALLET_REPO := github.com/decred/dcrwallet
-DCRWALLET_COMMIT := 1920377bb49f66318ed4630de9a32b245f90d2a2
+DCRWALLET_COMMIT := release-v2.0.0
 DCRWALLET_META := $(DCRWALLET_COMMIT).from-dcrlnd
 DCRWALLET_LDFLAGS := "-X decred.org/dcrwallet/version.BuildMetadata=$(DCRWALLET_META)"
 DCRWALLET_TMPDIR := $(shell mktemp -d)

--- a/docs/release-notes/release-notes-0.7.0.md
+++ b/docs/release-notes/release-notes-0.7.0.md
@@ -1,0 +1,40 @@
+# dcrlnd v0.7.0
+
+This release is the first release for the v2.0 line of Decred tool releases.
+
+While dcrlnd itself has few changes, it brings in all changes inherited from
+the [corresponding dcrwallet 
+release](https://github.com/decred/dcrwallet/releases/tag/release-v2.0.0).
+
+The following is the list of dcrlnd-specific changes for v0.7.0.
+
+- Additional logging for [pathfinding](https://github.com/decred/dcrlnd/pull/212) 
+  and [topology changes](https://github.com/decred/dcrlnd/pull/209) to help
+  debug payment failures.
+
+- Fixed issue with [future timestamps](https://github.com/decred/dcrlnd/pull/211) 
+  causing the gossiper to fail to fetch updates upon reconnecting to a peer.
+
+- [Improved the performance](https://github.com/decred/dcrlnd/pull/208) of the
+  Mission Control Store, in particular for clients that make only occasional
+  payments or otherwise sit idle for long periods of time.
+
+- [Exposed the 
+  `disablerelaytx`](https://github.com/decred/dcrlnd/pull/213/commits/36a71209b25c5fa67ab1160561a31e30bf75145f)
+  config argument that was recently introduced by dcrwallet to disable receiving
+  mempool transactions from peers.
+
+- [Passing the aezeed
+  birthday](https://github.com/decred/dcrlnd/pull/213/commits/53c91821abbe4d9a93c61b23a853960275e29a6d)
+  to dcrwallet when creating or restoring a dcrlnd instance, making both
+  operations significantly faster, in particular creation of wallets from new
+  seeds, which remove the need for long-running and cpu-intensive account and
+  address discovery stages.
+
+
+
+# Contributors (Alphabetical Order)
+
+  - David Hill
+  - Matheus Degiovani
+

--- a/lntest/itest/lnd_open_channel_test.go
+++ b/lntest/itest/lnd_open_channel_test.go
@@ -164,9 +164,9 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Connecting to the temporary miner should now cause our original
 	// chain to be re-orged out.
-	err = rpctest.ConnectNode(ctxb, net.Miner.Harness, tempMiner.Harness)
+	err = rpctest.ConnectNode(testctx.New(t), net.Miner.Harness, tempMiner.Harness)
 	if err != nil {
-		t.Fatalf("unable to remove node: %v", err)
+		t.Fatalf("unable to connect nodes: %v", err)
 	}
 
 	nodes := []*rpctest.Harness{tempMiner.Harness, net.Miner.Harness}


### PR DESCRIPTION
- Change the binaries used in integration tests to use the recently tagged release-v2.0.0 binaries.
- Add v0.7.0 release notes.