### PR TITLE
chainntnfs: Fix detection for no txindex error

### DIFF
--- a/chainntnfs/interface.go
+++ b/chainntnfs/interface.go
@@ -654,7 +654,7 @@ func IsTxIndexDisabledError(err error) bool {
 		return false
 	}
 
-	errNoTxIndexMsg := "The transaction index must be enabled"
+	errNoTxIndexMsg := "the transaction index must be enabled"
 	return strings.Contains(err.Error(), errNoTxIndexMsg)
 }
 


### PR DESCRIPTION
This was changed at some point in dcrd, so it need to be fixed here.
