### PR TITLE
fix gap limit set as 0

### DIFF
--- a/config_builder.go
+++ b/config_builder.go
@@ -314,7 +314,7 @@ func (d *DefaultWalletImpl) BuildWalletConfig(ctx context.Context,
 		// We have the password now, we can ask the unlocker service to
 		// do the unlock for us.
 		unlockedWallet, unloadWalletFn, err := d.pwService.LoadAndUnlock(
-			ctx, pwBytes, 0,
+			ctx, pwBytes, wallet.DefaultGapLimit,
 		)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("error unlocking "+


### PR DESCRIPTION
When using dcrlnd as a daemon, the config builder sets the gap limit to 0, causing the wallet to crash.

This PR fixes the issue.
