### PR TITLE
dcrwallet: Disable mixing by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/dcrlnd
 go 1.20
 
 require (
-	decred.org/dcrwallet/v4 v4.3.0
+	decred.org/dcrwallet/v4 v4.3.1
 	github.com/NebulousLabs/go-upnp v0.0.0-20181203152547-b32978b8ccbf
 	github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344
 	github.com/bahlo/generic-list-go v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 decred.org/cspp/v2 v2.4.0 h1:whb0YW+UELHJS/UfT5MBXSJXrKUVw5omhgKNhjzYix4=
 decred.org/cspp/v2 v2.4.0/go.mod h1:9nO3bfvCheOPIFZw5f6sRQ42CjBFB5RKSaJ9Iq6G4MA=
-decred.org/dcrwallet/v4 v4.3.0 h1:JqFyUa5Xj51br1In8wzQresUrW5nuGp7cCFIxpb4VZE=
-decred.org/dcrwallet/v4 v4.3.0/go.mod h1:cd0+55eXPYwYddb/8r3dRyXI+MXiqx642QisZbswzUI=
+decred.org/dcrwallet/v4 v4.3.1 h1:6OZ1GS9YvLk2/SGZc2Tw11QV3sqkov431da7sBd7Bc0=
+decred.org/dcrwallet/v4 v4.3.1/go.mod h1:cd0+55eXPYwYddb/8r3dRyXI+MXiqx642QisZbswzUI=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/lnwallet/dcrwallet/loader/loader.go
+++ b/lnwallet/dcrwallet/loader/loader.go
@@ -186,6 +186,7 @@ func (l *Loader) CreateWatchingOnlyWallet(ctx context.Context, extendedPubKey st
 		AllowHighFees:           l.allowHighFees,
 		RelayFee:                l.relayFee,
 		Params:                  l.chainParams,
+		DisableMixing:           true,
 	}
 	w, err = wallet.Open(ctx, cfg)
 	if err != nil {
@@ -277,6 +278,7 @@ func (l *Loader) CreateNewWallet(ctx context.Context, pubPassphrase,
 		AllowHighFees:           l.allowHighFees,
 		RelayFee:                l.relayFee,
 		Params:                  l.chainParams,
+		DisableMixing:           true,
 	}
 	w, err = wallet.Open(ctx, cfg)
 	if err != nil {
@@ -338,6 +340,7 @@ func (l *Loader) OpenExistingWallet(ctx context.Context, pubPassphrase []byte) (
 		AllowHighFees:           l.allowHighFees,
 		RelayFee:                l.relayFee,
 		Params:                  l.chainParams,
+		DisableMixing:           true,
 	}
 	w, err = wallet.Open(ctx, cfg)
 	if err != nil {


### PR DESCRIPTION
The existing LN interfaces (dcrlncli, decrediton, gRPC) do not support mixing from an embedded wallet instance. This commits disables mixing to avoid unnecessary load in dcrlnd wallets.

